### PR TITLE
lmsensors: add workaround for upstream mainline kernel support

### DIFF
--- a/recipes-bsp/lm_sensors/files/fancontrol-hwinit.service
+++ b/recipes-bsp/lm_sensors/files/fancontrol-hwinit.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=PWM Fan Configuration
+ConditionFileNotEmpty=/etc/fancontrol
+ConditionPathExists=/sys/class/hwmon/hwmon0/pwm1_enable
+Before=fancontrol.service
+Wants=fancontrol.service
+
+[Service]
+Type=simple
+ExecStart=/bin/sh -c 'echo 3 > /sys/class/hwmon/hwmon0/pwm1_enable'
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-bsp/lm_sensors/files/fancontrol.patch
+++ b/recipes-bsp/lm_sensors/files/fancontrol.patch
@@ -1,0 +1,29 @@
+--- /prog/pwm/fancontrol.orig
++++ /prog/pwm/fancontrol
+@@ -398,9 +398,12 @@
+ function pwmdisable()
+ {
+ 	local ENABLE=${1}_enable
++	local NAME="$(dirname ${1})/name"
++	local DRVNAME="$(cat $NAME)"
+ 
+-	# No enable file? Just set to max
+-	if [ ! -f $ENABLE ]
++	# No enable file? Just set to max;
++	# pwmfan driver implements enable file, but with different purpose
++	if [ ! -f $ENABLE ] || [ "$DRVNAME" = "pwmfan" ]
+ 	then
+ 		echo $MAX > $1
+ 		return 0
+@@ -469,8 +472,10 @@
+ function pwmenable()
+ {
+ 	local ENABLE=${1}_enable
++	local NAME="$(dirname ${1})/name"
++	local DRVNAME="$(cat $NAME)"
+ 
+-	if [ -f $ENABLE ]
++	if [ -f $ENABLE ] && [ "$DRVNAME" != "pwmfan" ]
+ 	then
+ 		# save the original pwmN_control state, e.g. 1 for manual or 2 for auto,
+ 		# and the value from pwmN

--- a/recipes-bsp/lm_sensors/files/pwmconfig.patch
+++ b/recipes-bsp/lm_sensors/files/pwmconfig.patch
@@ -1,0 +1,46 @@
+--- /prog/pwm/pwmconfig.orig
++++ /prog/pwm/pwmconfig
+@@ -157,6 +157,14 @@
+ function is_pwm_auto()
+ {
+ 	local ENABLE=${1}_enable
++	local NAME="$(dirname ${1})/name"
++	local DRVNAME="$(cat $NAME)"
++
++	# pwmfan driver does not implement auto mode
++	if [ "$DRVNAME" = "pwmfan" ]
++	then
++		return 1
++	fi
+ 
+ 	if [ -f $ENABLE ]
+ 	then
+@@ -173,9 +181,12 @@
+ function pwmdisable()
+ {
+ 	local ENABLE=${1}_enable
++	local NAME="$(dirname ${1})/name"
++	local DRVNAME="$(cat $NAME)"
+ 
+-	# No enable file? Just set to max
+-	if [ ! -f $ENABLE ]
++	# No enable file? Just set to max;
++	# pwmfan driver implements enable file, but with different purpose
++	if [ ! -f $ENABLE ] || [ "$DRVNAME" = "pwmfan" ]
+ 	then
+ 		echo $MAX > $1
+ 		return 0
+@@ -213,8 +224,12 @@
+ function pwmenable()
+ {
+ 	local ENABLE=${1}_enable
++	local NAME="$(dirname ${1})/name"
++	local DRVNAME="$(cat $NAME)"
+ 
+-	if [ -w $ENABLE ]
++	# enable pwm, but only if driver is not pwmfan since
++	# this one implements enable with different purpose
++	if [ -w $ENABLE ] && [ "$DRVNAME" != "pwmfan" ]
+ 	then
+ 		echo 1 2>/dev/null > $ENABLE
+ 		if [ $? -ne 0 ]

--- a/recipes-bsp/lm_sensors/lmsensors-config_%.bbappend
+++ b/recipes-bsp/lm_sensors/lmsensors-config_%.bbappend
@@ -1,3 +1,21 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 PACKAGECONFIG ?= ""
+
+inherit systemd
+
+SRC_URI += " file://fancontrol-hwinit.service"
+
+do_install:append() {
+    # install systemd service file
+    if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
+        install -d -m 0755 ${D}${systemd_system_unitdir}
+        install -m 0644 ${WORKDIR}/fancontrol-hwinit.service ${D}${systemd_system_unitdir}
+    fi
+}
+
+SYSTEMD_PACKAGES += "${PN}-fancontrol"
+SYSTEMD_SERVICE:${PN}-fancontrol = "fancontrol-hwinit.service"
+SYSTEMD_AUTO_ENABLE = "enable"
+
+FILES:${PN}-fancontrol += "${systemd_system_unitdir}/fancontrol-hwinit.service"

--- a/recipes-bsp/lm_sensors/lmsensors_%.bbappend
+++ b/recipes-bsp/lm_sensors/lmsensors_%.bbappend
@@ -9,7 +9,7 @@ SYSTEMD_SERVICE:${PN}-fancontrol = "fancontrol.service"
 SYSTEMD_AUTO_ENABLE = "enable"
 
 do_install:append() {
-    # Insall sensord service script
+    # install systemd service file
     if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
         install -m 0644 ${WORKDIR}/fancontrol.service ${D}${systemd_system_unitdir}
     fi

--- a/recipes-bsp/lm_sensors/lmsensors_%.bbappend
+++ b/recipes-bsp/lm_sensors/lmsensors_%.bbappend
@@ -1,6 +1,10 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-SRC_URI += " file://fancontrol.service"
+SRC_URI += " \
+    file://fancontrol.service \
+    file://fancontrol.patch \
+    file://pwmconfig.patch \
+"
 
 PACKAGECONFIG ?= ""
 


### PR DESCRIPTION
This PR adds patches for lmsensor package, which allow using the config script and the fancontrol script itself which newer kernel versions where the sysfs hwmon API changed.
It also adds a tiny systemd service script which configures the pwmfan driver during bootup.

Signed-off-by: Michael Heimpold <michael.heimpold@chargebyte.com>