### PR TITLE
libwebsockets: backport two patches from upstream

### DIFF
--- a/recipes-connectivity/libwebsockets/files/0001-netlink-fix-empty-route-index-discovery.patch
+++ b/recipes-connectivity/libwebsockets/files/0001-netlink-fix-empty-route-index-discovery.patch
@@ -1,0 +1,55 @@
+From 919981fba64f45e563efddd833bdd01f63afa0a1 Mon Sep 17 00:00:00 2001
+From: Andy Green <andy@warmcat.com>
+Date: Tue, 14 Sep 2021 08:07:10 +0100
+Subject: [PATCH] netlink: fix empty route index discovery
+
+---
+ lib/core-net/route.c | 13 +++++++++----
+ 1 file changed, 9 insertions(+), 4 deletions(-)
+
+diff --git a/lib/core-net/route.c b/lib/core-net/route.c
+index 9b4dbebb..9fdbb780 100644
+--- a/lib/core-net/route.c
++++ b/lib/core-net/route.c
+@@ -96,11 +96,15 @@ _lws_routing_table_dump(struct lws_context *cx)
+ lws_route_uidx_t
+ _lws_route_get_uidx(struct lws_context *cx)
+ {
++	uint8_t ou;
++
+ 	if (!cx->route_uidx)
+ 		cx->route_uidx++;
+ 
+-	while (1) {
+-		char again = 0;
++	ou = cx->route_uidx;
++
++	do {
++		uint8_t again = 0;
+ 
+ 		/* Anybody in the table already uses the pt's next uidx? */
+ 
+@@ -113,17 +117,18 @@ _lws_route_get_uidx(struct lws_context *cx)
+ 				cx->route_uidx++;
+ 				if (!cx->route_uidx)
+ 					cx->route_uidx++;
+-				if (again) {
++				if (cx->route_uidx == ou) {
+ 					assert(0); /* we have filled up the 8-bit uidx space? */
+ 					return 0;
+ 				}
+ 				again = 1;
++				break;
+ 			}
+ 		} lws_end_foreach_dll(d);
+ 
+ 		if (!again)
+ 			return cx->route_uidx++;
+-	}
++	} while (1);
+ }
+ 
+ lws_route_t *
+-- 
+2.34.1
+

--- a/recipes-connectivity/libwebsockets/files/0001-route-extend-lws_route_uidx_t-from-1-byte-to-2-bytes.patch
+++ b/recipes-connectivity/libwebsockets/files/0001-route-extend-lws_route_uidx_t-from-1-byte-to-2-bytes.patch
@@ -1,0 +1,40 @@
+From 73b61f6a2ebeb02f1fb81f27dde3b55944398026 Mon Sep 17 00:00:00 2001
+From: wayneonway <121931005@qq.com>
+Date: Mon, 21 Feb 2022 15:16:35 +0800
+Subject: [PATCH] route: extend lws_route_uidx_t from 1 byte to 2 bytes
+
+---
+ include/libwebsockets/lws-network-helper.h | 3 ++-
+ lib/core-net/route.c                       | 2 +-
+ 2 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/include/libwebsockets/lws-network-helper.h b/include/libwebsockets/lws-network-helper.h
+index 20a32253..09308b8b 100644
+--- a/include/libwebsockets/lws-network-helper.h
++++ b/include/libwebsockets/lws-network-helper.h
+@@ -33,7 +33,8 @@
+ #include <lwip/sockets.h>
+ #endif
+ 
+-typedef uint8_t lws_route_uidx_t;
++/* cope with large amounts of route information */
++typedef uint16_t lws_route_uidx_t;
+ 
+ typedef struct lws_dns_score {
+ 	uint8_t precedence;
+diff --git a/lib/core-net/route.c b/lib/core-net/route.c
+index 7013ef84..14f4beb0 100644
+--- a/lib/core-net/route.c
++++ b/lib/core-net/route.c
+@@ -103,7 +103,7 @@ _lws_routing_table_dump(struct lws_context *cx)
+ lws_route_uidx_t
+ _lws_route_get_uidx(struct lws_context *cx)
+ {
+-	uint8_t ou;
++	lws_route_uidx_t ou;
+ 
+ 	if (!cx->route_uidx)
+ 		cx->route_uidx++;
+-- 
+2.34.1
+

--- a/recipes-connectivity/libwebsockets/libwebsockets_4.2.2.bbappend
+++ b/recipes-connectivity/libwebsockets/libwebsockets_4.2.2.bbappend
@@ -1,0 +1,6 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += " \
+    file://0001-netlink-fix-empty-route-index-discovery.patch \
+    file://0001-route-extend-lws_route_uidx_t-from-1-byte-to-2-bytes.patch \
+"


### PR DESCRIPTION
Customer reported following error which resulted in crash of mosquitto broker:

- snip (wrapped+shortened for readability) -
mosquitto: .../libwebsockets/4.2.2-r0/git/lib/core-net/route.c:117:
  _lws_route_get_uidx: Assertion `0' failed.
- snap -

This might be related to libwebsockets#2414 so let's backport two patches from upstream which could resolve this issue.
