### PR TITLE
packagegroup-develop: drop subversion from package list

### DIFF
--- a/packagegroups/packagegroup-develop.bb
+++ b/packagegroups/packagegroup-develop.bb
@@ -47,7 +47,6 @@ RDEPENDS:${PN} = " \
     sqlite3 \
     strace \
     stress-ng \
-    subversion \
     systemd-analyze \
     tmux \
 "


### PR DESCRIPTION
subversion is not widely used anymore, so let's drop it from the default development list.

If needed, it still can be included in custom builds using EXTRA_PACKAGES in local.conf, IMAGE_INSTALL:append or similar mechanisms.