### PR TITLE
bsp-basefiles: rework boot notification LED handling

### DIFF
--- a/recipes-core/bsp-basefiles/bsp-basefiles.bb
+++ b/recipes-core/bsp-basefiles/bsp-basefiles.bb
@@ -2,7 +2,7 @@ LICENSE = "CLOSED"
 
 inherit systemd
 
-PV = "1.18"
+PV = "1.19"
 
 PACKAGE_ARCH = "all"
 

--- a/recipes-core/bsp-basefiles/files/led-boot-notification.service
+++ b/recipes-core/bsp-basefiles/files/led-boot-notification.service
@@ -1,10 +1,11 @@
+#
+# This script re-configures the boot LED after successfully booting of the board.
+#
+
 [Unit]
 Description=LED boot notification
-#
-# This script sets the green LED to on after successfully booting of the board.
-#
 After=rauc-mark-good.service
-Requires=watchdogd.service
+Requires=rauc-mark-good.service
 
 [Service]
 Type=oneshot

--- a/recipes-core/bsp-basefiles/files/led-boot-notification.sh
+++ b/recipes-core/bsp-basefiles/files/led-boot-notification.sh
@@ -4,6 +4,9 @@
 
 MODEL=$(tr -d '\0' < /proc/device-tree/model)
 
+# fallback if not overridden later
+TRIGGER="none"
+
 case "$MODEL" in
 "I2SE EVAcharge SE")
 	LED="evse:green:led3"
@@ -14,9 +17,15 @@ case "$MODEL" in
 "I2SE Tarragon"*)
 	LED="evse:green:led1"
 	;;
+"chargebyte Charge SOM"*)
+	LED="red:boot"
+	TRIGGER="heartbeat"
+	;;
 *)
 	exit 0
 esac
 
-led_set_attr "$LED" "trigger" "none"
-led_set_attr "$LED" "brightness" 200
+led_set_attr "$LED" "trigger" "$TRIGGER"
+
+MAXBRIGHTNESS="$(led_get_attr "$LED" "max_brightness")"
+led_set_attr "$LED" "brightness" "$MAXBRIGHTNESS"


### PR DESCRIPTION
Rework the handling of LED boot notification:
- we should not depend on services which are not part of this layer so let's drop the reference to watchdogd.service
- we want to ensure that the current system state is fine before switching the LED behavior so switching the Requires to rauc-mark-good.service seems reasonable
- add support for Charge SOM (which has only a single user LED on the example baseboard, so the behavior is slightly different to our other boards)

While at, refactor the setting of max_brightness to get rid of then (probably) random value used at the moment.