### PR TITLE
Add new package tulum-utils and add it to packagegroups

### DIFF
--- a/packagegroups/packagegroup-chargesom.bb
+++ b/packagegroups/packagegroup-chargesom.bb
@@ -13,6 +13,7 @@ RDEPENDS:${PN} = " \
     tpm2-pkcs11 \
     tpm2-tools \
     tpm2-tss-engine \
+    tulum-utils \
     wpa-supplicant \
     wpa-supplicant-cli \
     wpa-supplicant-passphrase \

--- a/packagegroups/packagegroup-develop.bb
+++ b/packagegroups/packagegroup-develop.bb
@@ -49,5 +49,6 @@ RDEPENDS:${PN} = " \
     stress-ng \
     systemd-analyze \
     tmux \
+    ${@bb.utils.contains("MACHINE", "chargesom", "tulum-utils-bash-completion", "", d)} \
     vim \
 "

--- a/recipes-connectivity/tulum-utils/tulum-utils_0.7.bb
+++ b/recipes-connectivity/tulum-utils/tulum-utils_0.7.bb
@@ -1,0 +1,26 @@
+SUMMARY = "Command line tools for MSE102x chipset interaction"
+DESCRIPTION = "hpav_test is simple command-line utility to help users to test MMEs, \
+               operate config file, operate nvram, and so on."
+HOMEPAGE = "https://github.com/Vertexcom-dev/tulum_utils"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=dbc8c49aa6fe32a4b70291423a8264f4"
+
+SRC_URI = "git://github.com/Vertexcom-dev/tulum_utils.git;protocol=https;branch=main"
+
+SRCREV = "ca9e0b5042229847c1d4cc89378400ba0fdb2ef2"
+PV = "0.7+git${SRCPV}"
+
+S = "${WORKDIR}/git"
+
+DEPENDS = "openssl libpcap zlib"
+
+inherit bash-completion
+
+EXTRA_OEMAKE += "-C hpav_test"
+
+do_install() {
+    oe_runmake install DESTDIR=${D}
+}
+
+FILES:${PN} = "${sbindir}"


### PR DESCRIPTION
This tool can be used to configure, control and test the Vertexcom MSE102x chipset as used on the upcoming Charge SOM platform.
