### PR TITLE
systemd related maintainance changes

### DIFF
--- a/recipes-core/bsp-basefiles/bsp-basefiles.bb
+++ b/recipes-core/bsp-basefiles/bsp-basefiles.bb
@@ -2,7 +2,7 @@ LICENSE = "CLOSED"
 
 inherit systemd
 
-PV = "1.19"
+PV = "1.20"
 
 PACKAGE_ARCH = "all"
 
@@ -55,8 +55,6 @@ do_install() {
 
     install -d ${D}/lib/systemd/system
     install -o root -g root -m 0644 ${WORKDIR}/led-boot-notification.service ${D}/lib/systemd/system
-    install -d ${D}${sysconfdir}/systemd/system/multi-user.target.wants
-    ln -sf /lib/systemd/system/led-boot-notification.service ${D}${sysconfdir}/systemd/system/multi-user.target.wants/led-boot-notification.service
 
     install -d ${D}/lib/udev/rules.d
     install -o root -g root -m 0644 ${WORKDIR}/udev/* ${D}/lib/udev/rules.d/
@@ -88,7 +86,7 @@ do_install() {
 
 FILES:${PN} = "/"
 
-SYSTEMD_SERVICE:${PN} = "srv.mount usb-mount@.service"
+SYSTEMD_SERVICE:${PN} = "srv.mount usb-mount@.service led-boot-notification.service"
 
 RDEPENDS:${PN} += " \
     e2fsprogs-e2fsck \

--- a/recipes-core/images/core-image-minimal.bbappend
+++ b/recipes-core/images/core-image-minimal.bbappend
@@ -3,3 +3,15 @@ tune_ext4fs () {
 }
 
 IMAGE_CMD:ext4 = "oe_mkext234fs ext4 ${EXTRA_IMAGECMD}; tune_ext4fs"
+
+clean_etc_systemd_stuff() {
+    # we want /etc/systemd/system clean, so move stuff to /lib/systemd/system
+    cp -a ${IMAGE_ROOTFS}${sysconfdir}/systemd/system/* ${IMAGE_ROOTFS}${systemd_unitdir}/system
+    rm -rf ${IMAGE_ROOTFS}${sysconfdir}/systemd/system/*
+
+    # this is a marker for the fw update that it is safe to migrate this directory
+    echo "# this file is a marker for firmware updates that this directory can be migrated" > \
+        ${IMAGE_ROOTFS}${sysconfdir}/systemd/system/.keep-during-fw-update
+}
+
+IMAGE_PREPROCESS_COMMAND:append = " clean_etc_systemd_stuff; "


### PR DESCRIPTION
One small cleanup for the bsp-basefiles which re-uses existing functionality,
one big change which clears the /etc/systemd/system directory in the root filesystem as preparation for keeping it during firmware updates.