### PR TITLE
Revert "packagegroup-develop: add node-red and nodejs-npm for Charge …

### DIFF
--- a/packagegroups/packagegroup-develop.bb
+++ b/packagegroups/packagegroup-develop.bb
@@ -32,7 +32,6 @@ RDEPENDS:${PN} = " \
     libiio-tests \
     lmbench \
     ${@bb.utils.contains("MACHINE", "tarragon", "lmsensors-pwmconfig", "", d)} \
-    ${@bb.utils.contains("MACHINE", "chargesom", "node-red nodejs-npm", "", d)} \
     mc \
     memtester \
     nano \


### PR DESCRIPTION
…SOM"

This reverts commit af021ce8d7251b4b02de2df8a46544cf24a03363.

Since node-red recipe is a backport in meta-everest layer, we should not include it here but in our meta-chargebyte-everest layer. See https://github.com/chargebyte/meta-chargebyte-everest/pull/31