### PR TITLE
packagegroups-{chargesom,tarragon}: replace crda with wireless-regdb-…

### DIFF
--- a/packagegroups/packagegroup-chargesom.bb
+++ b/packagegroups/packagegroup-chargesom.bb
@@ -9,7 +9,7 @@ RDEPENDS:${PN} = " \
     can-utils-essentials \
     cb-eeprom-utils \
     cc33xx-fw \
-    crda \
+    wireless-regdb-static \
     hostapd \
     iw \
     ra-utils \

--- a/packagegroups/packagegroup-tarragon.bb
+++ b/packagegroups/packagegroup-tarragon.bb
@@ -7,7 +7,7 @@ inherit packagegroup
 
 RDEPENDS:${PN} = " \
     ${@bb.utils.contains("SUBMACHINE", "micro", "", "cc-qca-fixup", d)} \
-    crda \
+    wireless-regdb-static \
     hostapd \
     iw \
     ${@bb.utils.contains("SUBMACHINE", "micro", "", "lmsensors-fancontrol", d)} \


### PR DESCRIPTION
…static

The crda package was only required for kernel < 4.15. Newer kernels handle regulatory stuff via /lib/firmware/regulatory.db* so let's switch to this newer approach.