### PR TITLE
recipes-backports: add elfutils v0.191

### DIFF
--- a/recipes-backports/elfutils/elfutils_0.191.bb
+++ b/recipes-backports/elfutils/elfutils_0.191.bb
@@ -1,0 +1,184 @@
+SUMMARY = "Utilities and libraries for handling compiled object files"
+HOMEPAGE = "https://sourceware.org/elfutils"
+DESCRIPTION = "elfutils is a collection of utilities and libraries to read, create and modify ELF binary files, find and handle DWARF debug data, symbols, thread state and stacktraces for processes and core files on GNU/Linux."
+SECTION = "base"
+LICENSE = "( GPL-2.0-or-later | LGPL-3.0-or-later ) & GPL-3.0-or-later"
+LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504 \
+                    file://debuginfod/debuginfod-client.c;endline=28;md5=f0a7c3170776866ee94e8f9225a6ad79 \
+                    "
+DEPENDS = "zlib virtual/libintl"
+DEPENDS:append:libc-musl = " argp-standalone fts musl-legacy-error musl-obstack"
+# The Debian patches below are from:
+# http://ftp.de.debian.org/debian/pool/main/e/elfutils/elfutils_0.176-1.debian.tar.xz
+SRC_URI = "https://sourceware.org/elfutils/ftp/${PV}/${BP}.tar.bz2 \
+           file://run-ptest \
+           file://0001-dso-link-change.patch \
+           file://0002-Fix-elf_cvt_gunhash-if-dest-and-src-are-same.patch \
+           file://0003-fixheadercheck.patch \
+           file://0006-Fix-build-on-aarch64-musl.patch \
+           file://0001-libasm-may-link-with-libbz2-if-found.patch \
+           file://0001-libelf-elf_end.c-check-data_list.data.d.d_buf-before.patch \
+           file://0001-skip-the-test-when-gcc-not-deployed.patch \
+           file://ptest.patch \
+           file://0001-tests-Makefile.am-compile-test_nlist-with-standard-C.patch \
+           file://0001-debuginfod-Remove-unused-variable.patch \
+           file://0001-srcfiles-fix-unused-variable-BUFFER_SIZE.patch \
+           file://CVE-2025-1352.patch \
+           file://CVE-2025-1365.patch \
+           file://CVE-2025-1372.patch \
+           file://CVE-2025-1371.patch \
+           file://0007-Fix-build-with-gcc-15.patch \
+           file://CVE-2025-1376.patch \
+           file://CVE-2025-1377.patch \
+           "
+SRC_URI:append:libc-musl = " \
+           file://0003-musl-utils.patch \
+           "
+SRC_URI[sha256sum] = "df76db71366d1d708365fc7a6c60ca48398f14367eb2b8954efc8897147ad871"
+
+inherit autotools gettext ptest pkgconfig
+
+EXTRA_OECONF = "--program-prefix=eu-"
+
+# Only used at runtime for make check but we want deterministic makefiles for ptest so hardcode
+CACHED_CONFIGUREVARS += "ac_cv_prog_HAVE_BUNZIP2=yes"
+
+BUILD_CFLAGS += "-Wno-error=stringop-overflow"
+
+DEPENDS_BZIP2 = "bzip2-replacement-native"
+DEPENDS_BZIP2:class-target = "bzip2"
+
+PACKAGECONFIG ??= "${@bb.utils.contains('DISTRO_FEATURES', 'debuginfod', 'debuginfod libdebuginfod', '', d)} \
+                   ${@bb.utils.contains('DISTRO_FEATURES', 'minidebuginfo', 'xz', '', d)} \
+                  "
+PACKAGECONFIG[bzip2] = "--with-bzlib,--without-bzlib,${DEPENDS_BZIP2}"
+PACKAGECONFIG[xz] = "--with-lzma,--without-lzma,xz"
+PACKAGECONFIG[zstd] = "--with-zstd,--without-zstd,zstd"
+PACKAGECONFIG[libdebuginfod] = "--enable-libdebuginfod,--disable-libdebuginfod,curl"
+PACKAGECONFIG[debuginfod] = "--enable-debuginfod,--disable-debuginfod,libarchive sqlite3 libmicrohttpd"
+
+RDEPENDS:${PN}-ptest += "libasm libelf bash make coreutils ${PN}-binutils iproute2-ss bsdtar gcc-symlinks binutils-symlinks libgcc-dev"
+
+EXTRA_OECONF:append:class-target = " --disable-tests-rpath"
+
+# symver functions not currently supported on microblaze
+EXTRA_OECONF:append:class-target:microblaze = " --disable-symbol-versioning"
+
+RDEPENDS:${PN}-ptest:append:libc-glibc = " glibc-utils glibc-dbg glibc-dev"
+INSANE_SKIP:${PN}-ptest = "debug-deps dev-deps"
+
+do_compile_ptest() {
+	cd ${B}/tests
+	oe_runmake buildtest-TESTS oecheck
+}
+PTEST_PARALLEL_MAKE = ""
+
+do_install_ptest() {
+	if [ ${PTEST_ENABLED} = "1" ]; then
+		# copy the files which needed by the cases
+		TEST_FILES="strip strip.o addr2line elfcmp objdump readelf size.o nm.o nm elflint elfcompress elfclassify stack unstrip srcfiles"
+		install -d -m 755                       ${D}${PTEST_PATH}/src
+		install -d -m 755                       ${D}${PTEST_PATH}/lib
+		install -d -m 755                       ${D}${PTEST_PATH}/libelf
+		install -d -m 755                       ${D}${PTEST_PATH}/libdw
+		install -d -m 755                       ${D}${PTEST_PATH}/libdwfl
+		install -d -m 755                       ${D}${PTEST_PATH}/libdwelf
+		install -d -m 755                       ${D}${PTEST_PATH}/libasm
+		install -d -m 755                       ${D}${PTEST_PATH}/libcpu
+		install -d -m 755                       ${D}${PTEST_PATH}/libebl
+		for test_file in ${TEST_FILES}; do
+			if [ -f ${B}/src/${test_file} ]; then
+				cp -r ${B}/src/${test_file} ${D}${PTEST_PATH}/src
+			fi
+		done
+		cp ${D}${libdir}/libelf-${PV}.so ${D}${PTEST_PATH}/libelf/libelf.so
+		cp ${D}${libdir}/libdw-${PV}.so ${D}${PTEST_PATH}/libdw/libdw.so
+		cp ${D}${libdir}/libasm-${PV}.so ${D}${PTEST_PATH}/libasm/libasm.so
+		cp ${B}/libcpu/libcpu.a ${D}${PTEST_PATH}/libcpu/
+		cp ${B}/libebl/libebl.a ${D}${PTEST_PATH}/libebl/
+		cp ${B}/lib/libeu.a ${D}${PTEST_PATH}/lib/
+		cp ${S}/libelf/*.h             ${D}${PTEST_PATH}/libelf/
+		cp ${S}/libdw/*.h              ${D}${PTEST_PATH}/libdw/
+		cp ${S}/libdwfl/*.h            ${D}${PTEST_PATH}/libdwfl/
+		cp ${S}/libdwelf/*.h           ${D}${PTEST_PATH}/libdwelf/
+		cp ${S}/libasm/*.h             ${D}${PTEST_PATH}/libasm/
+		cp -r ${S}/tests/                       ${D}${PTEST_PATH}
+		cp -r ${B}/tests/*                      ${D}${PTEST_PATH}/tests
+		cp -r ${B}/config.h                     ${D}${PTEST_PATH}
+		cp -r ${B}/backends                     ${D}${PTEST_PATH}
+		cp -r ${B}/debuginfod                   ${D}${PTEST_PATH}
+		sed -i '/^Makefile:/c Makefile:'        ${D}${PTEST_PATH}/tests/Makefile
+		find ${D}${PTEST_PATH} -type f -name *.[hoc] | xargs -i rm {}
+	fi
+}
+
+EXTRA_OEMAKE:class-native = ""
+EXTRA_OEMAKE:class-nativesdk = ""
+
+BBCLASSEXTEND = "native nativesdk"
+
+# Package utilities and libraries are listed separately
+PACKAGES =+ "${PN}-binutils libelf libasm libdw libdebuginfod"
+
+# According to the upstream website https://sourceware.org/elfutils, the latest
+# license policy is as follows:
+# "License. The libraries and backends are dual GPLv2+/LGPLv3+. The utilities
+# are GPLv3+."
+LICENSE:${PN}-binutils = "GPL-3.0-or-later"
+LICENSE:${PN} = "GPL-3.0-or-later"
+LICENSE:libelf = "GPL-2.0-or-later | LGPL-3.0-or-later"
+LICENSE:libasm = "GPL-2.0-or-later | LGPL-3.0-or-later"
+LICENSE:libdw = "GPL-2.0-or-later | LGPL-3.0-or-later"
+LICENSE:libdebuginfod = "GPL-2.0-or-later | LGPL-3.0-or-later"
+
+FILES:${PN}-binutils = "\
+    ${bindir}/eu-addr2line \
+    ${bindir}/eu-ld \
+    ${bindir}/eu-nm \
+    ${bindir}/eu-readelf \
+    ${bindir}/eu-size \
+    ${bindir}/eu-strip"
+
+FILES:libelf = "${libdir}/libelf-${PV}.so ${libdir}/libelf.so.*"
+FILES:libasm = "${libdir}/libasm-${PV}.so ${libdir}/libasm.so.*"
+FILES:libdw  = "${libdir}/libdw-${PV}.so ${libdir}/libdw.so.* ${libdir}/elfutils/lib*"
+FILES:libdebuginfod = "${libdir}/libdebuginfod-${PV}.so ${libdir}/libdebuginfod.so.*"
+# Some packages have the version preceeding the .so instead properly
+# versioned .so.<version>, so we need to reorder and repackage.
+#FILES:${PN} += "${libdir}/*-${PV}.so ${base_libdir}/*-${PV}.so"
+#FILES_SOLIBSDEV = "${libdir}/libasm.so ${libdir}/libdw.so ${libdir}/libelf.so"
+
+# The package contains symlinks that trip up insane
+INSANE_SKIP:${MLPREFIX}libdw = "dev-so"
+# The nlist binary in the tests uses explicitly minimal compiler flags
+INSANE_SKIP:${PN}-ptest += "ldflags"
+
+# avoid stripping some generated binaries otherwise some of the tests such as test-nlist,
+# run-strip-reloc.sh, run-strip-strmerge.sh and so on will fail
+INHIBIT_PACKAGE_STRIP_FILES = "\
+    ${PKGD}${PTEST_PATH}/tests/test-nlist \
+    ${PKGD}${PTEST_PATH}/tests/elfstrmerge \
+    ${PKGD}${PTEST_PATH}/tests/backtrace-child \
+    ${PKGD}${PTEST_PATH}/tests/backtrace-data \
+    ${PKGD}${PTEST_PATH}/tests/backtrace-dwarf \
+    ${PKGD}${PTEST_PATH}/tests/deleted \
+    ${PKGD}${PTEST_PATH}/tests/dwfllines \
+    ${PKGD}${PTEST_PATH}/src/strip \
+    ${PKGD}${PTEST_PATH}/src/addr2line \
+    ${PKGD}${PTEST_PATH}/src/elfcmp \
+    ${PKGD}${PTEST_PATH}/src/objdump \
+    ${PKGD}${PTEST_PATH}/src/readelf \
+    ${PKGD}${PTEST_PATH}/src/nm \
+    ${PKGD}${PTEST_PATH}/src/elflint \
+    ${PKGD}${PTEST_PATH}/src/elfclassify \
+    ${PKGD}${PTEST_PATH}/src/stack \
+    ${PKGD}${PTEST_PATH}/src/unstrip \
+    ${PKGD}${PTEST_PATH}/src/srcfiles \
+    ${PKGD}${PTEST_PATH}/libelf/libelf.so \
+    ${PKGD}${PTEST_PATH}/libdw/libdw.so \
+    ${PKGD}${PTEST_PATH}/libasm/libasm.so \
+    ${PKGD}${PTEST_PATH}/backends/libebl_i386.so \
+    ${PKGD}${PTEST_PATH}/backends/libebl_x86_64.so \
+"
+
+PRIVATE_LIBS:${PN}-ptest = "libdw.so.1 libelf.so.1 libasm.so.1 libdebuginfod.so.1"

--- a/recipes-backports/elfutils/files/0001-debuginfod-Remove-unused-variable.patch
+++ b/recipes-backports/elfutils/files/0001-debuginfod-Remove-unused-variable.patch
@@ -1,0 +1,34 @@
+From c3502140e51886bffc6ae5cd256308e40e0cbb78 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sat, 9 Mar 2024 15:52:32 -0800
+Subject: [PATCH] debuginfod: Remove unused variable
+
+Recent commit acd9525e9 has removed all references to max_fds
+therefore remove it, moreover clang18 is happier
+
+| ../../elfutils-0.191/debuginfod/debuginfod.cxx:1448:8: error: private field 'max_fds' is not used [-Werror,-Wunused-private-field]
+|  1448 |   long max_fds;
+|       |        ^
+| 1 error generated.
+
+Upstream-Status: Submitted [https://sourceware.org/pipermail/elfutils-devel/2024q1/006900.html]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ debuginfod/debuginfod.cxx | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/debuginfod/debuginfod.cxx b/debuginfod/debuginfod.cxx
+index 560880f2..72617848 100644
+--- a/debuginfod/debuginfod.cxx
++++ b/debuginfod/debuginfod.cxx
+@@ -1445,7 +1445,6 @@ private:
+ 
+   map<key,fdcache_entry> entries; // optimized for lookup
+   time_t last_cleaning;
+-  long max_fds;
+   long max_mbs;
+ 
+ public:
+-- 
+2.44.0
+

--- a/recipes-backports/elfutils/files/0001-dso-link-change.patch
+++ b/recipes-backports/elfutils/files/0001-dso-link-change.patch
@@ -1,0 +1,49 @@
+From 63070df4b0dc7af37a720915b5e6494204463c9a Mon Sep 17 00:00:00 2001
+From: Hongxu Jia <hongxu.jia@windriver.com>
+Date: Tue, 15 Aug 2017 17:10:57 +0800
+Subject: [PATCH] dso link change
+
+Upstream-Status: Pending
+
+This patch makes the link to the dependencies of libdw explicit, as
+recent ld no longer implicitly links them. See
+http://lists.fedoraproject.org/pipermail/devel/2010-March/133601.html
+as a similar example of the error message you can encounter without this
+patch, and https://fedoraproject.org/wiki/UnderstandingDSOLinkChange and
+https://fedoraproject.org/wiki/Features/ChangeInImplicitDSOLinking for
+more details.
+
+Rebase to 0.170
+
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+---
+ src/Makefile.am   | 2 +-
+ tests/Makefile.am | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 1d592d4..853eda4 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -50,7 +50,7 @@ libdebuginfod =
+ endif
+ else
+ libasm = ../libasm/libasm.so
+-libdw = ../libdw/libdw.so
++libdw = ../libdw/libdw.so $(zip_LIBS) $(libelf) $(libebl) -ldl
+ libelf = ../libelf/libelf.so
+ if LIBDEBUGINFOD
+ libdebuginfod = ../debuginfod/libdebuginfod.so
+diff --git a/tests/Makefile.am b/tests/Makefile.am
+index 9141074..ee49d07 100644
+--- a/tests/Makefile.am
++++ b/tests/Makefile.am
+@@ -694,7 +694,7 @@ libdw = ../libdw/libdw.a -lz $(zip_LIBS) $(libelf) $(libebl) -ldl -lpthread
+ libelf = ../libelf/libelf.a -lz $(zstd_LIBS)
+ libasm = ../libasm/libasm.a
+ else
+-libdw = ../libdw/libdw.so
++libdw = ../libdw/libdw.so $(zip_LIBS) $(libelf) $(libebl) -ldl
+ libelf = ../libelf/libelf.so
+ libasm = ../libasm/libasm.so
+ endif

--- a/recipes-backports/elfutils/files/0001-libasm-may-link-with-libbz2-if-found.patch
+++ b/recipes-backports/elfutils/files/0001-libasm-may-link-with-libbz2-if-found.patch
@@ -1,0 +1,39 @@
+From 46d9d889a07fc9f9f089f800e5c0e895889c44ae Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 4 Oct 2017 22:30:46 -0700
+Subject: [PATCH] libasm may link with libbz2 if found
+
+This can fail to link binaries like objdump
+where indirect libraries may be not found by linker
+
+| /mnt/a/oe/build/tmp/work/riscv64-bec-linux/elfutils/0.170-r0/recipe-sysroot/usr/lib/libbz2.so.1: error adding symbols: DSO missing from command line
+| collect2: error: ld returned 1 exit status
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/Makefile.am | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 853eda4..da7f3b4 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -40,7 +40,7 @@ EXTRA_DIST += make-debug-archive.in
+ CLEANFILES += make-debug-archive
+ 
+ if BUILD_STATIC
+-libasm = ../libasm/libasm.a
++libasm = ../libasm/libasm.a $(zip_LIBS)
+ libdw = ../libdw/libdw.a -lz $(zip_LIBS) $(libelf) -ldl -lpthread
+ libelf = ../libelf/libelf.a -lz $(zstd_LIBS)
+ if LIBDEBUGINFOD
+@@ -49,7 +49,7 @@ else
+ libdebuginfod =
+ endif
+ else
+-libasm = ../libasm/libasm.so
++libasm = ../libasm/libasm.so $(zip_LIBS)
+ libdw = ../libdw/libdw.so $(zip_LIBS) $(libelf) $(libebl) -ldl
+ libelf = ../libelf/libelf.so
+ if LIBDEBUGINFOD

--- a/recipes-backports/elfutils/files/0001-libelf-elf_end.c-check-data_list.data.d.d_buf-before.patch
+++ b/recipes-backports/elfutils/files/0001-libelf-elf_end.c-check-data_list.data.d.d_buf-before.patch
@@ -1,0 +1,43 @@
+From 19d9e9d838e74e4a0a22f08ae03167380f8aa490 Mon Sep 17 00:00:00 2001
+From: Robert Yang <liezhi.yang@windriver.com>
+Date: Thu, 16 Aug 2018 09:58:26 +0800
+Subject: [PATCH] libelf/elf_end.c: check data_list.data.d.d_buf before free it
+
+The one which actually saves the data is data_list.data.d.d_buf, so check it
+before free rawdata_base.
+
+This can fix a segmentation fault when prelink libqb_1.0.3:
+prelink: /usr/lib/libqb.so.0.18.2: Symbol section index outside of section numbers
+
+The segmentation fault happens when prelink call elf_end().
+
+Upstream-Status: Submitted [https://sourceware.org/ml/elfutils-devel/2018-q3/msg00085.html]
+
+Signed-off-by: Robert Yang <liezhi.yang@windriver.com>
+---
+ libelf/elf_end.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/libelf/elf_end.c b/libelf/elf_end.c
+index 80f4d13..b103959 100644
+--- a/libelf/elf_end.c
++++ b/libelf/elf_end.c
+@@ -169,14 +169,16 @@ elf_end (Elf *elf)
+ 		   architecture doesn't require overly stringent
+ 		   alignment the raw data buffer is the same as the
+ 		   one used for presenting to the caller.  */
+-		if (scn->data_base != scn->rawdata_base)
++		if ((scn->data_base != scn->rawdata_base)
++		    && (scn->data_list.data.d.d_buf != NULL))
+ 		  free (scn->data_base);
+ 
+ 		/* The section data is allocated if we couldn't mmap
+ 		   the file.  Or if we had to decompress.  */
+-		if (elf->map_address == NULL
++		if ((elf->map_address == NULL
+ 		    || scn->rawdata_base == scn->zdata_base
+ 		    || (scn->flags & ELF_F_MALLOCED) != 0)
++		    && (scn->data_list.data.d.d_buf != NULL))
+ 		  free (scn->rawdata_base);
+ 
+ 		/* Free the list of data buffers for the section.

--- a/recipes-backports/elfutils/files/0001-skip-the-test-when-gcc-not-deployed.patch
+++ b/recipes-backports/elfutils/files/0001-skip-the-test-when-gcc-not-deployed.patch
@@ -1,0 +1,70 @@
+From f9ab54454000fd210dbaa92cf516084d05060f9d Mon Sep 17 00:00:00 2001
+From: Mingli Yu <Mingli.Yu@windriver.com>
+Date: Tue, 21 May 2019 15:20:34 +0800
+Subject: [PATCH] skip the test when gcc not deployed
+
+Skip the tests which depend on gcc when
+gcc not deployed.
+
+Upstream-Status: Submitted [https://sourceware.org/ml/elfutils-devel/2019-q2/msg00091.html]
+
+Signed-off-by: Mingli Yu <Mingli.Yu@windriver.com>
+---
+ tests/run-disasm-x86-64.sh | 2 ++
+ tests/run-disasm-x86.sh    | 2 ++
+ tests/run-strip-g.sh       | 2 ++
+ tests/run-strip-nothing.sh | 2 ++
+ 4 files changed, 8 insertions(+)
+
+diff --git a/tests/run-disasm-x86-64.sh b/tests/run-disasm-x86-64.sh
+index 07b612b..7a32996 100755
+--- a/tests/run-disasm-x86-64.sh
++++ b/tests/run-disasm-x86-64.sh
+@@ -22,6 +22,8 @@ case "`uname -m`" in
+   x86_64)
+     tempfiles testfile45.o
+     testfiles testfile45.S testfile45.expect
++    # skip the case if no gcc deployed
++    which gcc || exit 77
+     ${CC} -m64 -c -o testfile45.o testfile45.S
+     testrun_compare ${abs_top_builddir}/src/objdump -d testfile45.o < testfile45.expect
+     ;;
+diff --git a/tests/run-disasm-x86.sh b/tests/run-disasm-x86.sh
+index 7ac73ad..f0d4796 100755
+--- a/tests/run-disasm-x86.sh
++++ b/tests/run-disasm-x86.sh
+@@ -22,6 +22,8 @@ case "`uname -m`" in
+   x86_64 | i?86 )
+     tempfiles testfile44.o
+     testfiles testfile44.S testfile44.expect
++    # skip the case if no gcc deployed
++    which gcc || exit 77
+     ${CC} -m32 -c -o testfile44.o testfile44.S
+     testrun_compare ${abs_top_builddir}/src/objdump -d testfile44.o < testfile44.expect
+     ;;
+diff --git a/tests/run-strip-g.sh b/tests/run-strip-g.sh
+index 1592121..9b8157e 100755
+--- a/tests/run-strip-g.sh
++++ b/tests/run-strip-g.sh
+@@ -24,6 +24,8 @@
+ 
+ tempfiles a.out strip.out debug.out readelf.out
+ 
++# skip the test if gcc deployed
++which gcc || exit 77
+ echo Create debug a.out.
+ echo "int main() { return 1; }" | ${CC} -g -xc -
+ 
+diff --git a/tests/run-strip-nothing.sh b/tests/run-strip-nothing.sh
+index 710c200..3a81d8e 100755
+--- a/tests/run-strip-nothing.sh
++++ b/tests/run-strip-nothing.sh
+@@ -22,6 +22,8 @@
+ 
+ tempfiles a.out strip.out debug.out
+ 
++# skip the case if no gcc deployed
++which gcc || exit 77
+ # Create no-debug a.out.
+ echo "int main() { return 1; }" | ${CC} -s -xc -
+ 

--- a/recipes-backports/elfutils/files/0001-srcfiles-fix-unused-variable-BUFFER_SIZE.patch
+++ b/recipes-backports/elfutils/files/0001-srcfiles-fix-unused-variable-BUFFER_SIZE.patch
@@ -1,0 +1,36 @@
+From db51a55a8e3811d19265bf12d2ff715c6cf558b4 Mon Sep 17 00:00:00 2001
+From: Jose Quaresma <jose.quaresma@foundries.io>
+Date: Tue, 19 Mar 2024 10:17:59 +0000
+Subject: [PATCH] srcfiles: fix unused variable BUFFER_SIZE
+
+The const variable BUFFER_SIZE is used only on the zip_files
+function witch is only available with LIBARCHIVE.
+
+| ../../elfutils-0.191/src/srcfiles.cxx:81:18: error: unused variable 'BUFFER_SIZE' [-Werror,-Wunused-const-variable]
+|    81 | constexpr size_t BUFFER_SIZE = 8192;
+|       |                  ^~~~~~~~~~~
+
+Upstream-Status: Backport [https://sourceware.org/git/?p=elfutils.git;a=commitdiff;h=ef8a4b841aaf26326b8961a651dbe915d54d23e7]
+
+Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>
+---
+ src/srcfiles.cxx | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/srcfiles.cxx b/src/srcfiles.cxx
+index 892737cc..09d50f8d 100644
+--- a/src/srcfiles.cxx
++++ b/src/srcfiles.cxx
+@@ -78,7 +78,9 @@ ARGP_PROGRAM_VERSION_HOOK_DEF = print_version;
+ /* Bug report address.  */
+ ARGP_PROGRAM_BUG_ADDRESS_DEF = PACKAGE_BUGREPORT;
+ 
++#ifdef HAVE_LIBARCHIVE
+ constexpr size_t BUFFER_SIZE = 8192;
++#endif
+ 
+ /* Definitions of arguments for argp functions.  */
+ static const struct argp_option options[] =
+-- 
+2.44.0
+

--- a/recipes-backports/elfutils/files/0001-tests-Makefile.am-compile-test_nlist-with-standard-C.patch
+++ b/recipes-backports/elfutils/files/0001-tests-Makefile.am-compile-test_nlist-with-standard-C.patch
@@ -1,0 +1,27 @@
+From 2d4dfb814dda02193e49c9203147cf73e6d3f8b7 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Tue, 23 Jun 2020 07:49:35 +0000
+Subject: [PATCH] tests/Makefile.am: compile test_nlist with standard CFLAGS
+
+Otherwise, it will contain build paths in it and wont
+be reproducible.
+
+Upstream-Status: Inappropriate [oe-core specific]
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+---
+ tests/Makefile.am | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tests/Makefile.am b/tests/Makefile.am
+index 3bd8e58..370c6a8 100644
+--- a/tests/Makefile.am
++++ b/tests/Makefile.am
+@@ -103,7 +103,7 @@ endif
+ test-nlist$(EXEEXT): test-nlist.c
+ 	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) \
+ 	  $(AM_CPPFLAGS) $(CPPFLAGS) \
+-	  $(test_nlist_CFLAGS) $(GCOV_FLAGS) -o $@ $< $(test_nlist_LDADD)
++	  $(CFLAGS) $(GCOV_FLAGS) -o $@ $< $(test_nlist_LDADD)
+ 
+ TESTS = run-arextract.sh run-arsymtest.sh run-ar.sh newfile test-nlist \
+ 	run-ar-N.sh \

--- a/recipes-backports/elfutils/files/0002-Fix-elf_cvt_gunhash-if-dest-and-src-are-same.patch
+++ b/recipes-backports/elfutils/files/0002-Fix-elf_cvt_gunhash-if-dest-and-src-are-same.patch
@@ -1,0 +1,39 @@
+From d8f07a23d608b744dcc0592f9f32f258b186a77c Mon Sep 17 00:00:00 2001
+From: Hongxu Jia <hongxu.jia@windriver.com>
+Date: Tue, 15 Aug 2017 17:13:59 +0800
+Subject: [PATCH] Fix elf_cvt_gunhash if dest and src are same.
+
+Upstream-Status: Pending
+
+The 'dest' and 'src' can be same, we need to save the value of src32[2]
+before swaping it.
+
+Signed-off-by: Baoshan Pang <BaoShan.Pang@windriver.com>
+
+Rebase to 0.170
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+---
+ libelf/gnuhash_xlate.h | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/libelf/gnuhash_xlate.h b/libelf/gnuhash_xlate.h
+index 3a00ae0..40468fc 100644
+--- a/libelf/gnuhash_xlate.h
++++ b/libelf/gnuhash_xlate.h
+@@ -42,6 +42,7 @@ elf_cvt_gnuhash (void *dest, const void *src, size_t len, int encode)
+      words.  We must detangle them here.   */
+   Elf32_Word *dest32 = dest;
+   const Elf32_Word *src32 = src;
++  Elf32_Word save_src32_2 = src32[2]; // dest could be equal to src
+ 
+   /* First four control words, 32 bits.  */
+   for (unsigned int cnt = 0; cnt < 4; ++cnt)
+@@ -52,7 +53,7 @@ elf_cvt_gnuhash (void *dest, const void *src, size_t len, int encode)
+       len -= 4;
+     }
+ 
+-  Elf32_Word bitmask_words = encode ? src32[2] : dest32[2];
++  Elf32_Word bitmask_words = encode ? save_src32_2 : dest32[2];
+ 
+   /* Now the 64 bit words.  */
+   Elf64_Xword *dest64 = (Elf64_Xword *) &dest32[4];

--- a/recipes-backports/elfutils/files/0003-fixheadercheck.patch
+++ b/recipes-backports/elfutils/files/0003-fixheadercheck.patch
@@ -1,0 +1,37 @@
+From 614f062b22e6da108643f8644a3e92a1108f2b9b Mon Sep 17 00:00:00 2001
+From: Hongxu Jia <hongxu.jia@windriver.com>
+Date: Tue, 15 Aug 2017 17:17:20 +0800
+Subject: [PATCH] fixheadercheck
+
+For some binaries we can get a invalid section alignment, for example if
+sh_align = 1 and sh_addralign is 0. In the case of a zero size section
+like
+".note.GNU-stack", this is irrelavent as far as I can tell and we
+shouldn't
+error in this case.
+
+RP 2014/6/11
+
+Upstream-Status: Pending
+
+Rebase to 0.170
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+---
+ libelf/elf32_updatenull.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/libelf/elf32_updatenull.c b/libelf/elf32_updatenull.c
+index 3594e8b..a3314e5 100644
+--- a/libelf/elf32_updatenull.c
++++ b/libelf/elf32_updatenull.c
+@@ -355,8 +355,8 @@ __elfw2(LIBELFBITS,updatenull_wrlock) (Elf *elf, int *change_bop, size_t shnum)
+ 		     we test for the alignment of the section being large
+ 		     enough for the largest alignment required by a data
+ 		     block.  */
+-		  if (unlikely (! powerof2 (shdr->sh_addralign))
+-		      || unlikely ((shdr->sh_addralign ?: 1) < sh_align))
++		  if (shdr->sh_size && (unlikely (! powerof2 (shdr->sh_addralign))
++		      || unlikely ((shdr->sh_addralign ?: 1) < sh_align)))
+ 		    {
+ 		      __libelf_seterrno (ELF_E_INVALID_ALIGN);
+ 		      return -1;

--- a/recipes-backports/elfutils/files/0003-musl-utils.patch
+++ b/recipes-backports/elfutils/files/0003-musl-utils.patch
@@ -1,0 +1,95 @@
+From aab5985a29bd7ab6e0b06eaab190b42a04e10f70 Mon Sep 17 00:00:00 2001
+From: Hongxu Jia <hongxu.jia@windriver.com>
+Date: Fri, 23 Aug 2019 10:19:48 +0800
+Subject: [PATCH] musl-utils
+
+Provide missing defines which otherwise are available on glibc system headers
+
+Alter the error API to match posix version
+use qsort instead of qsort_r which is glibc specific API
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Upstream-Status: Inappropriate [workaround for musl]
+
+Rebase to 0.177
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+---
+ src/arlib.h       | 6 ++++++
+ src/elfcompress.c | 7 +++++++
+ src/strip.c       | 7 +++++++
+ src/unstrip.c     | 9 +++++++++
+ 4 files changed, 29 insertions(+)
+
+diff --git a/src/arlib.h b/src/arlib.h
+index d4a4221..f6336d9 100644
+--- a/src/arlib.h
++++ b/src/arlib.h
+@@ -29,6 +29,12 @@
+ #include <stdint.h>
+ #include <sys/types.h>
+ 
++#if !defined(ALLPERMS)
++# define ALLPERMS (S_ISUID|S_ISGID|S_ISVTX|S_IRWXU|S_IRWXG|S_IRWXO) /* 07777 */
++#endif
++#if !defined(DEFFILEMODE)
++# define DEFFILEMODE (S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH)/* 0666*/
++#endif
+ 
+ /* State of -D/-U flags.  */
+ extern bool arlib_deterministic_output;
+diff --git a/src/elfcompress.c b/src/elfcompress.c
+index f771b92..263de62 100644
+--- a/src/elfcompress.c
++++ b/src/elfcompress.c
+@@ -37,6 +37,13 @@
+ #include "libeu.h"
+ #include "printversion.h"
+ 
++#if !defined(ALLPERMS)
++# define ALLPERMS (S_ISUID|S_ISGID|S_ISVTX|S_IRWXU|S_IRWXG|S_IRWXO) /* 07777 */
++#endif
++#if !defined(FNM_EXTMATCH)
++# define FNM_EXTMATCH (0)
++#endif
++
+ /* Name and version of program.  */
+ ARGP_PROGRAM_VERSION_HOOK_DEF = print_version;
+ 
+diff --git a/src/strip.c b/src/strip.c
+index 6436443..1608496 100644
+--- a/src/strip.c
++++ b/src/strip.c
+@@ -45,6 +45,13 @@
+ #include <system.h>
+ #include <printversion.h>
+ 
++#if !defined(ACCESSPERMS)
++# define ACCESSPERMS (S_IRWXU|S_IRWXG|S_IRWXO) /* 0777 */
++#endif
++#if !defined(FNM_EXTMATCH)
++# define FNM_EXTMATCH (0)
++#endif
++
+ typedef uint8_t GElf_Byte;
+ 
+ /* Name and version of program.  */
+diff --git a/src/unstrip.c b/src/unstrip.c
+index d70053d..b8a6ff3 100644
+--- a/src/unstrip.c
++++ b/src/unstrip.c
+@@ -51,6 +51,15 @@
+ #include "libeu.h"
+ #include "printversion.h"
+ 
++#ifndef strndupa
++#define strndupa(s, n) \
++       ({const char *__in = (s); \
++         size_t __len = strnlen (__in, (n)) + 1; \
++         char *__out = (char *) alloca (__len); \
++         __out[__len-1] = '\0'; \
++         (char *) memcpy (__out, __in, __len-1);})
++#endif
++
+ /* Name and version of program.  */
+ ARGP_PROGRAM_VERSION_HOOK_DEF = print_version;
+ 

--- a/recipes-backports/elfutils/files/0006-Fix-build-on-aarch64-musl.patch
+++ b/recipes-backports/elfutils/files/0006-Fix-build-on-aarch64-musl.patch
@@ -1,0 +1,58 @@
+From 4409f128c81a9d76b9360b002a1d76043c77b53e Mon Sep 17 00:00:00 2001
+From: Hongxu Jia <hongxu.jia@windriver.com>
+Date: Tue, 15 Aug 2017 17:27:30 +0800
+Subject: [PATCH] Fix build on aarch64/musl
+
+Errors
+
+invalid operands to binary & (have 'long double' and 'unsigned int')
+
+error: redefinition
+ of 'struct iovec'
+ struct iovec { void *iov_base; size_t iov_len; };
+        ^
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+Rebase to 0.170
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+---
+ backends/aarch64_initreg.c | 4 ++--
+ backends/arm_initreg.c     | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/backends/aarch64_initreg.c b/backends/aarch64_initreg.c
+index daf6f37..6445276 100644
+--- a/backends/aarch64_initreg.c
++++ b/backends/aarch64_initreg.c
+@@ -33,7 +33,7 @@
+ #include "system.h"
+ #include <assert.h>
+ #if defined(__aarch64__) && defined(__linux__)
+-# include <linux/uio.h>
++# include <sys/uio.h>
+ # include <sys/user.h>
+ # include <sys/ptrace.h>
+ /* Deal with old glibc defining user_pt_regs instead of user_regs_struct.  */
+@@ -82,7 +82,7 @@ aarch64_set_initial_registers_tid (pid_t tid __attribute__ ((unused)),
+ 
+   Dwarf_Word dwarf_fregs[32];
+   for (int r = 0; r < 32; r++)
+-    dwarf_fregs[r] = fregs.vregs[r] & 0xFFFFFFFF;
++    dwarf_fregs[r] = (unsigned int)fregs.vregs[r] & 0xFFFFFFFF;
+ 
+   if (! setfunc (64, 32, dwarf_fregs, arg))
+     return false;
+diff --git a/backends/arm_initreg.c b/backends/arm_initreg.c
+index efcabaf..062bb9e 100644
+--- a/backends/arm_initreg.c
++++ b/backends/arm_initreg.c
+@@ -38,7 +38,7 @@
+ #endif
+ 
+ #ifdef __aarch64__
+-# include <linux/uio.h>
++# include <sys/uio.h>
+ # include <sys/user.h>
+ # include <sys/ptrace.h>
+ /* Deal with old glibc defining user_pt_regs instead of user_regs_struct.  */

--- a/recipes-backports/elfutils/files/0007-Fix-build-with-gcc-15.patch
+++ b/recipes-backports/elfutils/files/0007-Fix-build-with-gcc-15.patch
@@ -1,0 +1,72 @@
+From 7508696d107ca01b65ce8273c881462a8658f90f Mon Sep 17 00:00:00 2001
+From: Sergei Trofimovich <slyich@gmail.com>
+Date: Wed, 17 Jul 2024 23:03:34 +0100
+Subject: [PATCH] backends: allocate enough stace for null terminator
+
+`gcc-15` added a new warning in https://gcc.gnu.org/PR115185:
+
+    i386_regs.c:88:11: error: initializer-string for array of 'char' is too long [-Werror=unterminated-string-initialization]
+       88 |           "ax", "cx", "dx", "bx", "sp", "bp", "si", "di", "ip"
+          |           ^~~~
+
+`elfutils` does not need to store '\0'. We could either initialize the
+arrays with individual bytes or allocate extra byte for null.
+
+This change initializes the array bytewise.
+
+	* backends/i386_regs.c (i386_register_info): Initialize the
+	array bytewise to fix gcc-15 warning.
+	* backends/x86_64_regs.c (x86_64_register_info): Ditto.
+
+Signed-off-by: Sergei Trofimovich <slyich@gmail.com>
+Upstream-Status: Backport [https://sourceware.org/git/?p=elfutils.git;a=commit;h=7508696d107ca01b65ce8273c881462a8658f90f]
+Signed-off-by: Martin Jansa <martin.jansa@gmail.com>
+---
+ backends/i386_regs.c   | 10 +++++++++-
+ backends/x86_64_regs.c |  9 ++++++++-
+ 2 files changed, 17 insertions(+), 2 deletions(-)
+
+diff --git a/backends/i386_regs.c b/backends/i386_regs.c
+index 7ec93bb9..ead55ef7 100644
+--- a/backends/i386_regs.c
++++ b/backends/i386_regs.c
+@@ -85,7 +85,15 @@ i386_register_info (Ebl *ebl __attribute__ ((unused)),
+     {
+       static const char baseregs[][2] =
+ 	{
+-	  "ax", "cx", "dx", "bx", "sp", "bp", "si", "di", "ip"
++	  {'a', 'x'},
++	  {'c', 'x'},
++	  {'d', 'x'},
++	  {'b', 'x'},
++	  {'s', 'p'},
++	  {'b', 'p'},
++	  {'s', 'i'},
++	  {'d', 'i'},
++	  {'i', 'p'},
+ 	};
+ 
+     case 4:
+diff --git a/backends/x86_64_regs.c b/backends/x86_64_regs.c
+index ef987daf..dab8f27f 100644
+--- a/backends/x86_64_regs.c
++++ b/backends/x86_64_regs.c
+@@ -82,7 +82,14 @@ x86_64_register_info (Ebl *ebl __attribute__ ((unused)),
+     {
+       static const char baseregs[][2] =
+ 	{
+-	  "ax", "dx", "cx", "bx", "si", "di", "bp", "sp"
++	  {'a', 'x'},
++	  {'d', 'x'},
++	  {'c', 'x'},
++	  {'b', 'x'},
++	  {'s', 'i'},
++	  {'d', 'i'},
++	  {'b', 'p'},
++	  {'s', 'p'},
+ 	};
+ 
+     case 6 ... 7:
+-- 
+2.43.7
+

--- a/recipes-backports/elfutils/files/CVE-2025-1352.patch
+++ b/recipes-backports/elfutils/files/CVE-2025-1352.patch
@@ -1,0 +1,153 @@
+From 2636426a091bd6c6f7f02e49ab20d4cdc6bfc753 Mon Sep 17 00:00:00 2001
+From: Mark Wielaard <mark@klomp.org>
+Date: Sat, 8 Feb 2025 20:00:12 +0100
+Subject: [PATCH] libdw: Simplify __libdw_getabbrev and fix dwarf_offabbrev
+ issue
+
+__libdw_getabbrev could crash on reading a bad abbrev by trying to
+deallocate memory it didn't allocate itself. This could happen because
+dwarf_offabbrev would supply its own memory when calling
+__libdw_getabbrev. No other caller did this.
+
+Simplify the __libdw_getabbrev common code by not taking external
+memory to put the abbrev result in (this would also not work correctly
+if the abbrev was already cached). And make dwarf_offabbrev explicitly
+copy the result (if there was no error or end of abbrev).
+
+     * libdw/dwarf_getabbrev.c (__libdw_getabbrev): Don't take
+     Dwarf_Abbrev result argument. Always just allocate abb when
+     abbrev not found in cache.
+     (dwarf_getabbrev): Don't pass NULL as last argument to
+     __libdw_getabbrev.
+    * libdw/dwarf_tag.c (__libdw_findabbrev): Likewise.
+    * libdw/dwarf_offabbrev.c (dwarf_offabbrev): Likewise. And copy
+    abbrev into abbrevp on success.
+    * libdw/libdw.h (dwarf_offabbrev): Document return values.
+    * libdw/libdwP.h (__libdw_getabbrev): Don't take Dwarf_Abbrev
+    result argument.
+
+https://sourceware.org/bugzilla/show_bug.cgi?id=32650
+
+Signed-off-by: Mark Wielaard <mark@klomp.org>
+
+Upstream-Status: Backport [https://sourceware.org/git/?p=elfutils.git;a=commit;h=2636426a091bd6c6f7f02e49ab20d4cdc6bfc753]
+CVE: CVE-2025-1352
+Signed-off-by: Hitendra Prajapati <hprajapati@mvista.com>
+---
+ libdw/dwarf_getabbrev.c | 12 ++++--------
+ libdw/dwarf_offabbrev.c | 10 +++++++---
+ libdw/dwarf_tag.c       |  3 +--
+ libdw/libdw.h           |  4 +++-
+ libdw/libdwP.h          |  3 +--
+ 5 files changed, 16 insertions(+), 16 deletions(-)
+
+diff --git a/libdw/dwarf_getabbrev.c b/libdw/dwarf_getabbrev.c
+index 5b02333..d9a6c02 100644
+--- a/libdw/dwarf_getabbrev.c
++++ b/libdw/dwarf_getabbrev.c
+@@ -1,5 +1,6 @@
+ /* Get abbreviation at given offset.
+    Copyright (C) 2003, 2004, 2005, 2006, 2014, 2017 Red Hat, Inc.
++   Copyright (C) 2025 Mark J. Wielaard <mark@klomp.org>
+    This file is part of elfutils.
+    Written by Ulrich Drepper <drepper@redhat.com>, 2003.
+ 
+@@ -38,7 +39,7 @@
+ Dwarf_Abbrev *
+ internal_function
+ __libdw_getabbrev (Dwarf *dbg, struct Dwarf_CU *cu, Dwarf_Off offset,
+-		   size_t *lengthp, Dwarf_Abbrev *result)
++		   size_t *lengthp)
+ {
+   /* Don't fail if there is not .debug_abbrev section.  */
+   if (dbg->sectiondata[IDX_debug_abbrev] == NULL)
+@@ -85,12 +86,7 @@ __libdw_getabbrev (Dwarf *dbg, struct Dwarf_CU *cu, Dwarf_Off offset,
+   Dwarf_Abbrev *abb = NULL;
+   if (cu == NULL
+       || (abb = Dwarf_Abbrev_Hash_find (&cu->abbrev_hash, code)) == NULL)
+-    {
+-      if (result == NULL)
+-	abb = libdw_typed_alloc (dbg, Dwarf_Abbrev);
+-      else
+-	abb = result;
+-    }
++    abb = libdw_typed_alloc (dbg, Dwarf_Abbrev);
+   else
+     {
+       foundit = true;
+@@ -183,5 +179,5 @@ dwarf_getabbrev (Dwarf_Die *die, Dwarf_Off offset, size_t *lengthp)
+       return NULL;
+     }
+ 
+-  return __libdw_getabbrev (dbg, cu, abbrev_offset + offset, lengthp, NULL);
++  return __libdw_getabbrev (dbg, cu, abbrev_offset + offset, lengthp);
+ }
+diff --git a/libdw/dwarf_offabbrev.c b/libdw/dwarf_offabbrev.c
+index 27cdad6..41df69b 100644
+--- a/libdw/dwarf_offabbrev.c
++++ b/libdw/dwarf_offabbrev.c
+@@ -41,11 +41,15 @@ dwarf_offabbrev (Dwarf *dbg, Dwarf_Off offset, size_t *lengthp,
+   if (dbg == NULL)
+     return -1;
+ 
+-  Dwarf_Abbrev *abbrev = __libdw_getabbrev (dbg, NULL, offset, lengthp,
+-					    abbrevp);
++  Dwarf_Abbrev *abbrev = __libdw_getabbrev (dbg, NULL, offset, lengthp);
+ 
+   if (abbrev == NULL)
+     return -1;
+ 
+-  return abbrev == DWARF_END_ABBREV ? 1 : 0;
++  if (abbrev == DWARF_END_ABBREV)
++    return 1;
++
++  *abbrevp = *abbrev;
++
++  return 0;
+ }
+diff --git a/libdw/dwarf_tag.c b/libdw/dwarf_tag.c
+index d784970..218382a 100644
+--- a/libdw/dwarf_tag.c
++++ b/libdw/dwarf_tag.c
+@@ -53,8 +53,7 @@ __libdw_findabbrev (struct Dwarf_CU *cu, unsigned int code)
+ 
+ 	/* Find the next entry.  It gets automatically added to the
+ 	   hash table.  */
+-	abb = __libdw_getabbrev (cu->dbg, cu, cu->last_abbrev_offset, &length,
+-				 NULL);
++	abb = __libdw_getabbrev (cu->dbg, cu, cu->last_abbrev_offset, &length);
+ 	if (abb == NULL || abb == DWARF_END_ABBREV)
+ 	  {
+ 	    /* Make sure we do not try to search for it again.  */
+diff --git a/libdw/libdw.h b/libdw/libdw.h
+index d53dc78..ec4713a 100644
+--- a/libdw/libdw.h
++++ b/libdw/libdw.h
+@@ -587,7 +587,9 @@ extern int dwarf_srclang (Dwarf_Die *die);
+ extern Dwarf_Abbrev *dwarf_getabbrev (Dwarf_Die *die, Dwarf_Off offset,
+ 				      size_t *lengthp);
+ 
+-/* Get abbreviation at given offset in .debug_abbrev section.  */
++/* Get abbreviation at given offset in .debug_abbrev section.  On
++   success return zero and fills in ABBREVP.  When there is no (more)
++   abbrev at offset returns one.  On error returns a negative value.  */
+ extern int dwarf_offabbrev (Dwarf *dbg, Dwarf_Off offset, size_t *lengthp,
+ 			    Dwarf_Abbrev *abbrevp)
+      __nonnull_attribute__ (4);
+diff --git a/libdw/libdwP.h b/libdw/libdwP.h
+index 8b2f06f..f0f4b78 100644
+--- a/libdw/libdwP.h
++++ b/libdw/libdwP.h
+@@ -783,8 +783,7 @@ extern Dwarf_Abbrev *__libdw_findabbrev (struct Dwarf_CU *cu,
+ 
+ /* Get abbreviation at given offset.  */
+ extern Dwarf_Abbrev *__libdw_getabbrev (Dwarf *dbg, struct Dwarf_CU *cu,
+-					Dwarf_Off offset, size_t *lengthp,
+-					Dwarf_Abbrev *result)
++					Dwarf_Off offset, size_t *lengthp)
+      __nonnull_attribute__ (1) internal_function;
+ 
+ /* Get abbreviation of given DIE, and optionally set *READP to the DIE memory
+-- 
+2.25.1
+

--- a/recipes-backports/elfutils/files/CVE-2025-1365.patch
+++ b/recipes-backports/elfutils/files/CVE-2025-1365.patch
@@ -1,0 +1,151 @@
+From 5e5c0394d82c53e97750fe7b18023e6f84157b81 Mon Sep 17 00:00:00 2001
+From: Mark Wielaard <mark@klomp.org>
+Date: Sat, 8 Feb 2025 21:44:56 +0100
+Subject: [PATCH] libelf, readelf: Use validate_str also to check dynamic
+ symstr data
+
+When dynsym/str was read through eu-readelf --dynamic by readelf
+process_symtab the string data was not validated, possibly printing
+unallocated memory past the end of the symstr data. Fix this by
+turning the elf_strptr validate_str function into a generic
+lib/system.h helper function and use it in readelf to validate the
+strings before use.
+
+	* libelf/elf_strptr.c (validate_str): Remove to...
+	* lib/system.h (validate_str): ... here. Make inline, simplify
+	check and document.
+	* src/readelf.c (process_symtab): Use validate_str on symstr_data.
+
+https://sourceware.org/bugzilla/show_bug.cgi?id=32654
+
+Signed-off-by: Mark Wielaard <mark@klomp.org>
+
+Upstream-Status: Backport [https://sourceware.org/git/?p=elfutils.git;a=commit;h=5e5c0394d82c53e97750fe7b18023e6f84157b81]
+CVE: CVE-2025-1365
+Signed-off-by: Hitendra Prajapati <hprajapati@mvista.com>
+---
+ lib/system.h        | 27 +++++++++++++++++++++++++++
+ libelf/elf_strptr.c | 18 ------------------
+ src/readelf.c       | 18 +++++++++++++++---
+ 3 files changed, 42 insertions(+), 21 deletions(-)
+
+diff --git a/lib/system.h b/lib/system.h
+index 0db12d9..0698e5f 100644
+--- a/lib/system.h
++++ b/lib/system.h
+@@ -34,6 +34,7 @@
+ #include <config.h>
+ 
+ #include <errno.h>
++#include <stdbool.h>
+ #include <stddef.h>
+ #include <stdint.h>
+ #include <string.h>
+@@ -117,6 +118,32 @@ startswith (const char *str, const char *prefix)
+   return strncmp (str, prefix, strlen (prefix)) == 0;
+ }
+ 
++/* Return TRUE if STR[FROM] is a valid string with a zero terminator
++   at or before STR[TO - 1].  Note FROM is an index into the STR
++   array, while TO is the maximum size of the STR array.  This
++   function returns FALSE when TO is zero or FROM >= TO.  */
++static inline bool
++validate_str (const char *str, size_t from, size_t to)
++{
++#if HAVE_DECL_MEMRCHR
++  // Check end first, which is likely a zero terminator,
++  // to prevent function call
++  return (to > 0
++	  && (str[to - 1] == '\0'
++	      || (to > from
++		  && memrchr (&str[from], '\0', to - from - 1) != NULL)));
++#else
++  do {
++    if (to <= from)
++      return false;
++
++    to--;
++  } while (str[to]);
++
++  return true;
++#endif
++}
++
+ /* A special gettext function we use if the strings are too short.  */
+ #define sgettext(Str) \
+   ({ const char *__res = strrchr (_(Str), '|');			      \
+diff --git a/libelf/elf_strptr.c b/libelf/elf_strptr.c
+index 79a24d2..c5a94f8 100644
+--- a/libelf/elf_strptr.c
++++ b/libelf/elf_strptr.c
+@@ -53,24 +53,6 @@ get_zdata (Elf_Scn *strscn)
+   return zdata;
+ }
+ 
+-static bool validate_str (const char *str, size_t from, size_t to)
+-{
+-#if HAVE_DECL_MEMRCHR
+-  // Check end first, which is likely a zero terminator, to prevent function call
+-  return ((to > 0 && str[to - 1]  == '\0')
+-	  || (to - from > 0 && memrchr (&str[from], '\0', to - from - 1) != NULL));
+-#else
+-  do {
+-    if (to <= from)
+-      return false;
+-
+-    to--;
+-  } while (str[to]);
+-
+-  return true;
+-#endif
+-}
+-
+ char *
+ elf_strptr (Elf *elf, size_t idx, size_t offset)
+ {
+diff --git a/src/readelf.c b/src/readelf.c
+index 0e93118..63eb548 100644
+--- a/src/readelf.c
++++ b/src/readelf.c
+@@ -2639,6 +2639,7 @@ process_symtab (Ebl *ebl, unsigned int nsyms, Elf64_Word idx,
+       char typebuf[64];
+       char bindbuf[64];
+       char scnbuf[64];
++      const char *sym_name;
+       Elf32_Word xndx;
+       GElf_Sym sym_mem;
+       GElf_Sym *sym
+@@ -2650,6 +2651,19 @@ process_symtab (Ebl *ebl, unsigned int nsyms, Elf64_Word idx,
+       /* Determine the real section index.  */
+       if (likely (sym->st_shndx != SHN_XINDEX))
+         xndx = sym->st_shndx;
++      if (use_dynamic_segment == true)
++	{
++	  if (validate_str (symstr_data->d_buf, sym->st_name,
++			    symstr_data->d_size))
++	    sym_name = (char *)symstr_data->d_buf + sym->st_name;
++	  else
++	    sym_name = NULL;
++	}
++      else
++	sym_name = elf_strptr (ebl->elf, idx, sym->st_name);
++
++      if (sym_name == NULL)
++	sym_name = "???";
+ 
+       printf (_ ("\
+ %5u: %0*" PRIx64 " %6" PRId64 " %-7s %-6s %-9s %6s %s"),
+@@ -2662,9 +2676,7 @@ process_symtab (Ebl *ebl, unsigned int nsyms, Elf64_Word idx,
+               get_visibility_type (GELF_ST_VISIBILITY (sym->st_other)),
+               ebl_section_name (ebl, sym->st_shndx, xndx, scnbuf,
+                                 sizeof (scnbuf), NULL, shnum),
+-              use_dynamic_segment == true
+-                  ? (char *)symstr_data->d_buf + sym->st_name
+-                  : elf_strptr (ebl->elf, idx, sym->st_name));
++              sym_name);
+ 
+       if (versym_data != NULL)
+         {
+-- 
+2.25.1
+

--- a/recipes-backports/elfutils/files/CVE-2025-1371.patch
+++ b/recipes-backports/elfutils/files/CVE-2025-1371.patch
@@ -1,0 +1,41 @@
+From b38e562a4c907e08171c76b8b2def8464d5a104a Mon Sep 17 00:00:00 2001
+From: Mark Wielaard <mark@klomp.org>
+Date: Sun, 9 Feb 2025 00:07:13 +0100
+Subject: [PATCH] readelf: Handle NULL phdr in handle_dynamic_symtab
+
+A corrupt ELF file can have broken program headers, in which case
+gelf_getphdr returns NULL. This could crash handle_dynamic_symtab
+while searching for the PT_DYNAMIC phdr. Fix this by checking whether
+gelf_phdr returns NULL.
+
+          * src/readelf.c (handle_dynamic_symtab): Check whether
+          gelf_getphdr returns NULL.
+
+https://sourceware.org/bugzilla/show_bug.cgi?id=32655
+
+Signed-off-by: Mark Wielaard <mark@klomp.org>
+
+CVE: CVE-2025-1371
+
+Upstream-Status: Backport [https://sourceware.org/cgit/elfutils/commit/?id=b38e562a4c907e08171c76b8b2def8464d5a104a]
+
+Signed-off-by: Soumya Sambu <soumya.sambu@windriver.com>
+---
+ src/readelf.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/readelf.c b/src/readelf.c
+index fc04556..13344bf 100644
+--- a/src/readelf.c
++++ b/src/readelf.c
+@@ -2912,7 +2912,7 @@ handle_dynamic_symtab (Ebl *ebl)
+   for (size_t i = 0; i < phnum; ++i)
+     {
+       phdr = gelf_getphdr (ebl->elf, i, &phdr_mem);
+-      if (phdr->p_type == PT_DYNAMIC)
++      if (phdr == NULL || phdr->p_type == PT_DYNAMIC)
+	break;
+     }
+   if (phdr == NULL)
+--
+2.40.0

--- a/recipes-backports/elfutils/files/CVE-2025-1372.patch
+++ b/recipes-backports/elfutils/files/CVE-2025-1372.patch
@@ -1,0 +1,50 @@
+From 73db9d2021cab9e23fd734b0a76a612d52a6f1db Mon Sep 17 00:00:00 2001
+From: Mark Wielaard <mark@klomp.org>
+Date: Sun, 9 Feb 2025 00:07:39 +0100
+Subject: [PATCH] readelf: Skip trying to uncompress sections without a name
+
+When combining eu-readelf -z with -x or -p to dump the data or strings
+in an (corrupted ELF) unnamed numbered section eu-readelf could crash
+trying to check whether the section name starts with .zdebug. Fix this
+by skipping sections without a name.
+
+   * src/readelf.c (dump_data_section): Don't try to gnu decompress a
+   section without a name.
+   (print_string_section): Likewise.
+
+https://sourceware.org/bugzilla/show_bug.cgi?id=32656
+
+Signed-off-by: Mark Wielaard <mark@klomp.org>
+
+Upstream-Status: Backport [https://sourceware.org/git/?p=elfutils.git;a=commit;h=73db9d2021cab9e23fd734b0a76a612d52a6f1db]
+CVE: CVE-2025-1372
+Signed-off-by: Hitendra Prajapati <hprajapati@mvista.com>
+---
+ src/readelf.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/readelf.c b/src/readelf.c
+index 63eb548..fc04556 100644
+--- a/src/readelf.c
++++ b/src/readelf.c
+@@ -13327,7 +13327,7 @@ dump_data_section (Elf_Scn *scn, const GElf_Shdr *shdr, const char *name)
+ 			_("Couldn't uncompress section"),
+ 			elf_ndxscn (scn));
+ 	    }
+-	  else if (startswith (name, ".zdebug"))
++	  else if (name && startswith (name, ".zdebug"))
+ 	    {
+ 	      if (elf_compress_gnu (scn, 0, 0) < 0)
+ 		printf ("WARNING: %s [%zd]\n",
+@@ -13378,7 +13378,7 @@ print_string_section (Elf_Scn *scn, const GElf_Shdr *shdr, const char *name)
+ 			_("Couldn't uncompress section"),
+ 			elf_ndxscn (scn));
+ 	    }
+-	  else if (startswith (name, ".zdebug"))
++	  else if (name && startswith (name, ".zdebug"))
+ 	    {
+ 	      if (elf_compress_gnu (scn, 0, 0) < 0)
+ 		printf ("WARNING: %s [%zd]\n",
+-- 
+2.25.1
+

--- a/recipes-backports/elfutils/files/CVE-2025-1376.patch
+++ b/recipes-backports/elfutils/files/CVE-2025-1376.patch
@@ -1,0 +1,58 @@
+From b16f441cca0a4841050e3215a9f120a6d8aea918 Mon Sep 17 00:00:00 2001
+From: Mark Wielaard <mark@klomp.org>
+Date: Thu, 13 Feb 2025 00:02:32 +0100
+Subject: [PATCH] libelf: Handle elf_strptr on section without any data
+
+In the unlikely situation that elf_strptr was called on a section with
+sh_size already set, but that doesn't have any data yet we could crash
+trying to verify the string to return.
+
+This could happen for example when a new section was created with
+elf_newscn, but no data having been added yet.
+
+        * libelf/elf_strptr.c (elf_strptr): Check strscn->rawdata_base
+        is not NULL.
+
+https://sourceware.org/bugzilla/show_bug.cgi?id=32672
+
+Signed-off-by: Mark Wielaard <mark@klomp.org>
+
+CVE: CVE-2025-1376
+
+Upstream-Status: Backport [https://sourceware.org/git/?p=elfutils.git;a=commit;h=b16f441cca0a4841050e3215a9f120a6d8aea918]
+
+Signed-off-by: Soumya Sambu <soumya.sambu@windriver.com>
+---
+ libelf/elf_strptr.c | 10 +++++++---
+ 1 file changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/libelf/elf_strptr.c b/libelf/elf_strptr.c
+index c5a94f8..7be7f5e 100644
+--- a/libelf/elf_strptr.c
++++ b/libelf/elf_strptr.c
+@@ -1,5 +1,6 @@
+ /* Return string pointer from string section.
+    Copyright (C) 1998-2002, 2004, 2008, 2009, 2015 Red Hat, Inc.
++   Copyright (C) 2025 Mark J. Wielaard <mark@klomp.org>
+    This file is part of elfutils.
+    Contributed by Ulrich Drepper <drepper@redhat.com>, 1998.
+ 
+@@ -183,9 +184,12 @@ elf_strptr (Elf *elf, size_t idx, size_t offset)
+       // initialized yet (when data_read is zero). So we cannot just
+       // look at the rawdata.d.d_size.
+ 
+-      /* Make sure the string is NUL terminated.  Start from the end,
+-	 which very likely is a NUL char.  */
+-      if (likely (validate_str (strscn->rawdata_base, offset, sh_size)))
++      /* First check there actually is any data.  This could be a new
++         section which hasn't had any data set yet.  Then make sure
++         the string is at a valid offset and NUL terminated.  */
++      if (unlikely (strscn->rawdata_base == NULL))
++	__libelf_seterrno (ELF_E_INVALID_SECTION);
++      else if (likely (validate_str (strscn->rawdata_base, offset, sh_size)))
+ 	result = &strscn->rawdata_base[offset];
+       else
+ 	__libelf_seterrno (ELF_E_INVALID_INDEX);
+-- 
+2.40.0
+

--- a/recipes-backports/elfutils/files/CVE-2025-1377.patch
+++ b/recipes-backports/elfutils/files/CVE-2025-1377.patch
@@ -1,0 +1,69 @@
+From fbf1df9ca286de3323ae541973b08449f8d03aba Mon Sep 17 00:00:00 2001
+From: Mark Wielaard <mark@klomp.org>
+Date: Thu, 13 Feb 2025 14:59:34 +0100
+Subject: [PATCH] strip: Verify symbol table is a real symbol table
+
+We didn't check the symbol table referenced from the relocation table
+was a real symbol table. This could cause a crash if that section
+happened to be an SHT_NOBITS section without any data. Fix this by
+adding an explicit check.
+
+       * src/strip.c (INTERNAL_ERROR_MSG): New macro that takes a
+       message string to display.
+       (INTERNAL_ERROR): Use INTERNAL_ERROR_MSG with elf_errmsg (-1).
+       (remove_debug_relocations): Check the sh_link referenced
+       section is real and isn't a SHT_NOBITS section.
+
+https://sourceware.org/bugzilla/show_bug.cgi?id=32673
+
+Signed-off-by: Mark Wielaard <mark@klomp.org>
+
+CVE: CVE-2025-1377
+
+Upstream-Status: Backport [https://sourceware.org/git/?p=elfutils.git;a=fbf1df9ca286de3323ae541973b08449f8d03aba]
+
+Signed-off-by: Soumya Sambu <soumya.sambu@windriver.com>
+---
+ src/strip.c | 14 +++++++++++---
+ 1 file changed, 11 insertions(+), 3 deletions(-)
+
+diff --git a/src/strip.c b/src/strip.c
+index 6436443..16922e9 100644
+--- a/src/strip.c
++++ b/src/strip.c
+@@ -126,13 +126,14 @@ static char *tmp_debug_fname = NULL;
+ /* Close debug file descriptor, if opened. And remove temporary debug file.  */
+ static void cleanup_debug (void);
+ 
+-#define INTERNAL_ERROR(fname) \
++#define INTERNAL_ERROR_MSG(fname, msg) \
+   do { \
+     cleanup_debug (); \
+     error_exit (0, _("%s: INTERNAL ERROR %d (%s): %s"),			\
+-		fname, __LINE__, PACKAGE_VERSION, elf_errmsg (-1));	\
++		fname, __LINE__, PACKAGE_VERSION, msg);	\
+   } while (0)
+ 
++#define INTERNAL_ERROR(fname) INTERNAL_ERROR_MSG(fname, elf_errmsg (-1))
+ 
+ /* Name of the output file.  */
+ static const char *output_fname;
+@@ -631,7 +632,14 @@ remove_debug_relocations (Ebl *ebl, Elf *elf, GElf_Ehdr *ehdr,
+ 	     resolve relocation symbol indexes.  */
+ 	  Elf64_Word symt = shdr->sh_link;
+ 	  Elf_Data *symdata, *xndxdata;
+-	  Elf_Scn * symscn = elf_getscn (elf, symt);
++	  Elf_Scn *symscn = elf_getscn (elf, symt);
++	  GElf_Shdr symshdr_mem;
++	  GElf_Shdr *symshdr = gelf_getshdr (symscn, &symshdr_mem);
++	  if (symshdr == NULL)
++	    INTERNAL_ERROR (fname);
++	  if (symshdr->sh_type == SHT_NOBITS)
++	    INTERNAL_ERROR_MSG (fname, "NOBITS section");
++
+ 	  symdata = elf_getdata (symscn, NULL);
+ 	  xndxdata = get_xndxdata (elf, symscn);
+ 	  if (symdata == NULL)
+-- 
+2.40.0
+

--- a/recipes-backports/elfutils/files/ptest.patch
+++ b/recipes-backports/elfutils/files/ptest.patch
@@ -1,0 +1,62 @@
+From d49f6a135762ec1f1831d0e80b8df2a4269b0a66 Mon Sep 17 00:00:00 2001
+From: Richard Purdie <richard.purdie@linuxfoundation.org>
+Date: Wed, 1 May 2019 16:37:48 +0100
+Subject: [PATCH] Changes to allow ptest to run standalone on target:
+
+a) Run the tests serially
+b) Use the standalone test mode which allows the tests to be run in their
+  'installled' locations on target (but not any of the standalone build pieces)
+c) We want to use the binaries from their installed locations so the run-subr
+   script needs tweaking to run them like that. The rpath conditional isn't
+   enough since we want the second entry in the case statement.
+d) Add an oecheck make target which we can use to build the test binaries we need
+
+Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>
+
+Upstream-Status: Inappropriate [oe specific]
+---
+ configure.ac       | 2 +-
+ tests/Makefile.am  | 2 ++
+ tests/test-subr.sh | 6 ------
+ 3 files changed, 3 insertions(+), 7 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index bbe8673..488712b 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -49,7 +49,7 @@ AC_COPYRIGHT([Copyright (C) 1996-2024 The elfutils developers.])
+ AC_PREREQ(2.63)			dnl Minimum Autoconf version required.
+ 
+ dnl We use GNU make extensions; automake 1.10 defaults to -Wportability.
+-AM_INIT_AUTOMAKE([gnits 1.11 -Wno-portability dist-bzip2 no-dist-gzip parallel-tests])
++AM_INIT_AUTOMAKE([gnits 1.11 -Wno-portability dist-bzip2 no-dist-gzip serial-tests])
+ AM_MAINTAINER_MODE
+ 
+ AM_SILENT_RULES([yes])
+diff --git a/tests/Makefile.am b/tests/Makefile.am
+index ee49d07..3bd8e58 100644
+--- a/tests/Makefile.am
++++ b/tests/Makefile.am
+@@ -852,3 +852,5 @@ check: check-am coverage
+ coverage:
+ 	-$(srcdir)/coverage.sh
+ endif
++oecheck:
++	$(MAKE) $(AM_MAKEFLAGS) $(check_PROGRAMS)
+diff --git a/tests/test-subr.sh b/tests/test-subr.sh
+index 411e5f2..a638ff9 100644
+--- a/tests/test-subr.sh
++++ b/tests/test-subr.sh
+@@ -91,12 +91,6 @@ installed_testrun()
+   program="$1"
+   shift
+   case "$program" in
+-  ${abs_builddir}/*)
+-    if [ "x$elfutils_tests_rpath" != xno ]; then
+-      echo >&2 installcheck not possible with --enable-tests-rpath
+-      exit 77
+-    fi
+-    ;;
+   ${abs_top_builddir}/src/*)
+     program=${bindir}/`program_transform ${program##*/}`
+     ;;

--- a/recipes-backports/elfutils/files/run-ptest
+++ b/recipes-backports/elfutils/files/run-ptest
@@ -1,0 +1,6 @@
+#!/bin/sh
+#
+#This script is used to run elfutils test suites
+cd tests
+
+make -k installcheck-local CC=gcc abs_srcdir=$PWD abs_builddir=$PWD srcdir=$PWD top_srcdir=$PWD/../ abs_top_builddir=$PWD/../ elfutils_testrun=installed elfutils_tests_rpath=no program_transform_name=s,^,eu-,


### PR DESCRIPTION
While kirkstone meanwhile announces support for Ubuntu 24.04 LTS as compatible platform, the older elfutils in kirkstone fail to build due to a curl deprecation warning on this distro:

```
 ../../elfutils-0.186/debuginfod/debuginfod-client.c:1158:11:
 error: ‘CURLINFO_CONTENT_LENGTH_DOWNLOAD’ is deprecated: since 7.55.0.
 Use CURLINFO_CONTENT_LENGTH_DOWNLOAD_T [-Werror=deprecated-declarations]
```

This backport imports elfutils from scarthgap branch.