### PR TITLE
mosquitto: add distro config sub-dir

### DIFF
--- a/recipes-connectivity/mosquitto/files/mosquitto.conf
+++ b/recipes-connectivity/mosquitto/files/mosquitto.conf
@@ -7,4 +7,5 @@ log_type error
 log_type warning
 connection_messages false
 allow_anonymous true
+include_dir /lib/mosquitto/conf.d
 include_dir /etc/mosquitto/conf.d

--- a/recipes-connectivity/mosquitto/mosquitto_%.bbappend
+++ b/recipes-connectivity/mosquitto/mosquitto_%.bbappend
@@ -14,8 +14,10 @@ do_install:append() {
     install -d ${D}${sysconfdir}/mosquitto/conf.d
     install -m 0644 ${WORKDIR}/confd-README ${D}${sysconfdir}/mosquitto/conf.d/README
 
+    install -d ${D}${nonarch_base_libdir}/mosquitto/conf.d
+
     install -d "${D}${sysconfdir}/logrotate.d"
     install -m 644 ${WORKDIR}/mosquitto.logrotate ${D}${sysconfdir}/logrotate.d/mosquitto
 }
 
-FILES:${PN}:append = " ${sysconfdir}/logrotate.d"
+FILES:${PN}:append = " ${sysconfdir}/logrotate.d ${nonarch_base_libdir}/mosquitto/conf.d"


### PR DESCRIPTION
This provides a place for additional distro-provided static configs (not migrated on updates), and adds use of this directory to the global mosquitto config.