### PR TITLE
Fine-tune default wifi support

### DIFF
--- a/recipes-connectivity/wpa-supplicant/wpa-supplicant/0001-Don-t-install-wpa_supplicant-.service.patch
+++ b/recipes-connectivity/wpa-supplicant/wpa-supplicant/0001-Don-t-install-wpa_supplicant-.service.patch
@@ -1,0 +1,32 @@
+From dd5368f663d68d228f8ae65168d07b3c1c649e81 Mon Sep 17 00:00:00 2001
+From: Michael Heimpold <michael.heimpold@chargebyte.com>
+Date: Thu, 28 May 2026 16:25:40 +0200
+Subject: [PATCH] Don't install wpa_supplicant@.service
+
+This causes timeouts during boot, we better use udev rules to
+trigger loading/starting of these units.
+
+Signed-off-by: Michael Heimpold <michael.heimpold@chargebyte.com>
+---
+ wpa_supplicant/systemd/wpa_supplicant.service.arg.in | 5 -----
+ 1 file changed, 5 deletions(-)
+
+diff --git a/wpa_supplicant/systemd/wpa_supplicant.service.arg.in b/wpa_supplicant/systemd/wpa_supplicant.service.arg.in
+index 55d2b9c81712..3e2dddb83f1e 100644
+--- a/wpa_supplicant/systemd/wpa_supplicant.service.arg.in
++++ b/wpa_supplicant/systemd/wpa_supplicant.service.arg.in
+@@ -5,11 +5,6 @@ After=sys-subsystem-net-devices-%i.device
+ Before=network.target
+ Wants=network.target
+ 
+-# NetworkManager users will probably want the dbus version instead.
+-
+ [Service]
+ Type=simple
+ ExecStart=@BINDIR@/wpa_supplicant -c/etc/wpa_supplicant/wpa_supplicant-%I.conf -i%I
+-
+-[Install]
+-WantedBy=multi-user.target
+-- 
+2.34.1
+

--- a/recipes-connectivity/wpa-supplicant/wpa-supplicant/10-cfg-present.conf
+++ b/recipes-connectivity/wpa-supplicant/wpa-supplicant/10-cfg-present.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionPathExists=/etc/wpa_supplicant/wpa_supplicant-%I.conf

--- a/recipes-connectivity/wpa-supplicant/wpa-supplicant/99-wifi.rules
+++ b/recipes-connectivity/wpa-supplicant/wpa-supplicant/99-wifi.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="net", ACTION=="add", KERNEL=="wlan*", TAG+="systemd", ENV{SYSTEMD_WANTS}+="wpa_supplicant@%k.service"

--- a/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
+++ b/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
@@ -1,3 +1,11 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += " \
+    file://0001-Don-t-install-wpa_supplicant-.service.patch \
+    file://99-wifi.rules \
+    file://10-cfg-present.conf \
+"
+
 PACKAGECONFIG ?= "openssl"
 
 do_install:append () {
@@ -6,4 +14,13 @@ do_install:append () {
 
 	# create config subdir
 	install -d ${D}${sysconfdir}/wpa_supplicant
+
+	install -d ${D}/lib/udev/rules.d
+	install -o root -g root -m 0644 ${WORKDIR}/99-wifi.rules ${D}/lib/udev/rules.d
+
+	# install config file condition
+	if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
+		install -d ${D}/${systemd_system_unitdir}/wpa_supplicant@.service.d
+		install -m 644 ${WORKDIR}/10-cfg-present.conf ${D}/${systemd_system_unitdir}/wpa_supplicant@.service.d/
+	fi
 }

--- a/recipes-core/bsp-network-config/bsp-network-config.bb
+++ b/recipes-core/bsp-network-config/bsp-network-config.bb
@@ -2,7 +2,7 @@ LICENSE = "CLOSED"
 
 inherit allarch
 
-PV = "11"
+PV = "12"
 
 SRC_URI = " \
     file://br0-mac-generator \

--- a/recipes-core/bsp-network-config/files/wlan0.network
+++ b/recipes-core/bsp-network-config/files/wlan0.network
@@ -5,5 +5,5 @@ Name=wlan0
 RequiredForOnline=no
 
 [Network]
-DHCP=no
-IPv6AcceptRA=no
+DHCP=yes
+IPv6AcceptRA=yes


### PR DESCRIPTION
This PR fine-tune the wifi support in our Charge Control OS:
- default is now DHCP enable for wifi
- wpa_supplicant is guarded by presence of config file
- some more firmware binaries are included (missing parts from older task)
