### PR TITLE
libbaptismdata: update to v0.2.0

### DIFF
--- a/recipes-bsp/libbaptismdata/files/bd-mdns-ssh.service
+++ b/recipes-bsp/libbaptismdata/files/bd-mdns-ssh.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Announce SSH server via mDNS
+After=network.target
+Wants=network.target
+
+[Service]
+type=simple
+ExecStart=/usr/sbin/bd-mdns -s -S 'chargebox_serial,serial,serial#'
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-bsp/libbaptismdata/libbaptismdata_0.2.0.bb
+++ b/recipes-bsp/libbaptismdata/libbaptismdata_0.2.0.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://LICENSES/LGPL-2.1-or-later.txt;md5=4fbd65380cdd255951
 SECTION = "libs"
 
 SRC_URI = "https://github.com/mhei/${BPN}/releases/download/v${PV}/${BPN}-${PV}.tar.xz"
-SRC_URI[sha256sum] = "43eeb1fd8f5cdbf9fd293c772cbdea3b5850012e08c37bbbb5e99409146c2774"
+SRC_URI[sha256sum] = "f1be8557abff1fa390f15d78e3833a77a7576ed28b9de9ffaef338b713f56bcb"
 
 inherit autotools pkgconfig
 

--- a/recipes-bsp/libbaptismdata/libbaptismdata_0.2.0.bb
+++ b/recipes-bsp/libbaptismdata/libbaptismdata_0.2.0.bb
@@ -8,11 +8,26 @@ LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM = "file://LICENSES/LGPL-2.1-or-later.txt;md5=4fbd65380cdd255951079008b364516c"
 SECTION = "libs"
 
-SRC_URI = "https://github.com/mhei/${BPN}/releases/download/v${PV}/${BPN}-${PV}.tar.xz"
+SRC_URI = "https://github.com/mhei/${BPN}/releases/download/v${PV}/${BPN}-${PV}.tar.xz file://bd-mdns-ssh.service"
 SRC_URI[sha256sum] = "f1be8557abff1fa390f15d78e3833a77a7576ed28b9de9ffaef338b713f56bcb"
 
-inherit autotools pkgconfig
+inherit autotools pkgconfig systemd
 
 DEPENDS = "libubootenv"
 
 RDEPENDS:${PN} += "libubootenv"
+
+PACKAGECONFIG ??= "mdns"
+
+PACKAGECONFIG[mdns] = "--with-avahi-mdns,--without-avahi-mdns,avahi"
+
+SYSTEMD_SERVICE:${PN} = "${@bb.utils.contains('PACKAGECONFIG', 'mdns', 'bd-mdns-ssh.service', '', d)}"
+
+do_install:append() {
+    # install systemd service file for SSH server annoucement
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)} && \
+       ${@bb.utils.contains('PACKAGECONFIG', 'mdns', 'true', 'false', d)}; then
+        install -d ${D}${systemd_system_unitdir}
+        install -m 0644 ${WORKDIR}/bd-mdns-ssh.service ${D}${systemd_system_unitdir}/
+    fi
+}


### PR DESCRIPTION
This PR adds a tiny tool which announces the SSH daemon via mDNS, enriched with some additional baptism data variables. This can be helpful for tools used during rollout, to find and list devices. While there is currently no cross-check that the SSH daemon is actually running/enabled, this can be added later.
