### PR TITLE
mse-nmk-store-fixup: introduce package

### DIFF
--- a/packagegroups/packagegroup-chargesom.bb
+++ b/packagegroups/packagegroup-chargesom.bb
@@ -8,6 +8,7 @@ inherit packagegroup
 RDEPENDS:${PN} = " \
     can-utils-essentials \
     cb-eeprom-utils \
+    mse-nmk-store-fixup \
     cc33xx-fw \
     bluez5 \
     wireless-regdb-static \

--- a/recipes-bsp/mse-nmk-store-fixup/files/84-mse-nmk-store-fixup.rules
+++ b/recipes-bsp/mse-nmk-store-fixup/files/84-mse-nmk-store-fixup.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="net", ACTION=="add", ENV{ID_NET_DRIVER}=="mse102x", TAG+="systemd", ENV{SYSTEMD_WANTS}+="mse-nmk-store-fixup@%k.service"

--- a/recipes-bsp/mse-nmk-store-fixup/files/mse-nmk-store-fixup.sh
+++ b/recipes-bsp/mse-nmk-store-fixup/files/mse-nmk-store-fixup.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+# This script fixes the MSE configuration to _not_ store NMK changes
+# peristantly in flash. This is to prevent flash wearout.
+#
+# Environment variable IFACE is set by udev rule.
+#
+
+# determine MSE MAC address
+FW_MAC="$(hpav_test find_local_sta "$IFACE" | grep "^MAC address" | head -n1 | cut -c57-74)"
+
+# in case we cannot determine the MAC, retry next boot
+[ -z "$FW_MAC" ] && exit 0
+
+# create temp workdir
+MY_TMPDIR="$(mktemp -d)"
+pushd "$MY_TMPDIR" > /dev/null
+
+# read current config
+hpav_test conf_file read "$IFACE" current-inka.conf "$FW_MAC" > /dev/null
+
+# check whether storing NMK changes is (still) enabled
+if hpav_test conf_file parse current-inka.conf | grep -q '^Store Key Change[[:space:]]*: true$'; then
+	echo "Store Key Change is (still) enabled for this MSE102x, fixing."
+
+	# modify config
+	hpav_test conf_file modify current-inka.conf store_key_change false
+
+	# write back config
+	hpav_test conf_file write "$IFACE" current-inka.conf "$FW_MAC" > /dev/null
+fi
+
+# cleanup
+popd > /dev/null
+rm -rf "$MY_TMPDIR"

--- a/recipes-bsp/mse-nmk-store-fixup/files/mse-nmk-store-fixup@.service
+++ b/recipes-bsp/mse-nmk-store-fixup/files/mse-nmk-store-fixup@.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=MSE102x NMK Store Fixup
+After=csom-mse102x-fixup@%i.service
+Before=mse-fw-update@%i.service everest.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/mse-nmk-store-fixup.sh
+Environment="IFACE=%i"

--- a/recipes-bsp/mse-nmk-store-fixup/mse-nmk-store-fixup.bb
+++ b/recipes-bsp/mse-nmk-store-fixup/mse-nmk-store-fixup.bb
@@ -1,0 +1,41 @@
+SUMMARY = "MSE102x configuration fixup to not store NMK changes in flash"
+DESCRIPTION = "Reads and - if necessary - fixes the configuration so that NMK changes \
+               are not stored in flash every time (e.g. during SLAC process)."
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+PV = "1"
+
+inherit allarch systemd
+
+SRC_URI = " \
+    file://84-mse-nmk-store-fixup.rules \
+    file://mse-nmk-store-fixup.sh \
+    file://mse-nmk-store-fixup@.service \
+"
+
+RDEPENDS:${PN} += "tulum-utils"
+
+do_install() {
+    install -d ${D}/usr/libexec
+    install -o root -g root -m 0755 ${WORKDIR}/mse-nmk-store-fixup.sh ${D}/usr/libexec/
+
+    install -d ${D}/lib/udev/rules.d
+    install -o root -g root -m 0644 ${WORKDIR}/84-mse-nmk-store-fixup.rules ${D}/lib/udev/rules.d/
+
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
+
+        install -d ${D}${systemd_system_unitdir}/
+        install -m 0644 ${WORKDIR}/mse-nmk-store-fixup@.service ${D}${systemd_system_unitdir}/
+
+        sed -i -e 's,@BASE_BINDIR@,${base_bindir},g' \
+               -e 's,@BINDIR@,${bindir},g' \
+               -e 's,@SBINDIR@,${sbindir},g' \
+               -e 's,@BINDIR@,${bindir},g' \
+               ${D}${systemd_system_unitdir}/*.service
+    fi
+}
+
+SYSTEMD_SERVICE:${PN} = "mse-nmk-store-fixup@.service"
+FILES:${PN} = "/"


### PR DESCRIPTION
This small package includes a startup helper which checks whether the attached MSE102x have proper configuration setting for store_nmk_change.